### PR TITLE
feat: initialize dark theme before styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Community wiki for [goingdark.social](https://goingdark.social).
 Built with [Hugo](https://gohugo.io) and the Hugo Blox documentation theme.
-The site now loads in dark mode by default, and you can switch themes from the header.
+The site loads in dark mode by default without a theme switcher.
 
 ## Local development
 

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1,0 +1,1 @@
+html, body { background-color: #000; }

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -43,7 +43,7 @@ header:
     button:
       enable: false
     show_search: true
-    show_theme_chooser: true
+    show_theme_chooser: false
 
 # Site footer
 footer:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,292 @@
+{{ $scr := .Scratch }}
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="generator" content="Hugo Blox Builder {{ site.Data.hugoblox.version }}" />
+
+  {{/* EXTENSIBILITY HOOK: HEAD-START */}}
+  {{ partial "functions/get_hook" (dict "hook" "head-start" "context" .) }}
+
+  {{ if .Params.private }}
+    <meta name="robots" content="noindex" />
+  {{- end -}}
+
+  {{/* Attempt to load superuser. */}}
+  {{ $superuser_name := "" }}
+  {{ $superuser_username := "" }}
+  {{ $superuser_role := "" }}
+  {{ range first 1 (where (where site.Pages "Section" "authors") "Params.superuser" true) }}
+    {{ $superuser_name = .Title }}
+    {{ $superuser_username = path.Base .File.Dir }}
+    {{ $superuser_role = .Params.role }}
+  {{ end }}
+  {{ $scr.Set "superuser_username" $superuser_username }}{{/* Set superuser globally for page_author.html. */}}
+
+  {{ with $superuser_name }}<meta name="author" content="{{ . }}" />{{ end }}
+
+  {{/* Generate page description. */}}
+  {{ $desc := "" }}
+  {{ if .Params.summary }}
+    {{ $desc = .Params.summary }}
+  {{ else if .Params.abstract }}
+    {{ $desc = .Params.abstract }}
+  {{ else if .IsPage }}
+    {{ $desc = .Summary }}
+  {{ else if site.Params.marketing.seo.description }}
+    {{ $desc = site.Params.marketing.seo.description }}
+  {{ else }}
+    {{ $desc = $superuser_role }}
+  {{ end }}
+  <meta name="description" content="{{ $desc | plainify }}" />
+
+  {{ range .Translations }}
+    <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+  {{ end }}
+  <link rel="alternate" hreflang="{{ site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}" />
+
+  {{ $custom := resources.Get "css/custom.scss" | toCSS | minify }}
+  <style>{{ $custom.Content | safeCSS }}</style>
+  <script>
+    const theme = localStorage.getItem('theme') || 'dark'
+    document.documentElement.dataset.theme = theme
+  </script>
+
+  {{/* Hugo Blox Color Theme Initialization */}}
+  {{ $theme_name := (lower site.Params.appearance.color) | default "blue" }}
+  {{ $theme_path := printf "css/themes/%s.css" $theme_name }}
+  {{ if not (fileExists (printf "assets/%s" $theme_path)) }}
+    {{ errorf "The specified color theme `%s.css` was not found in `assets/css/themes/`. Either install your custom color theme in the folder or set the `color` theme value in `params.yaml` to an existing theme such as `blue`." $theme_name }}
+  {{ else }}
+    {{ $theme_css := resources.Get $theme_path | minify }}
+    <link rel="stylesheet" href="{{ $theme_css.RelPermalink }}" />
+  {{ end }}
+
+  {{/* Style */}}
+  {{ if ne (os.Getenv "HUGO_BLOX_POSTCSS") "true" }}
+    {{ $styles := resources.Get "dist/wc.min.css" | fingerprint "sha256" }}
+    <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
+  {{ else }}
+    {{ $options := dict "inlineImports" true }}
+    {{ $styles := resources.Get "css/styles.css" }}
+    {{ $styles = $styles | resources.PostCSS $options }}
+    {{ if  hugo.IsProduction  }}
+      {{ $styles = $styles | minify | fingerprint "sha256" | resources.PostProcess }}
+    {{ end }}
+    <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
+  {{ end }}
+
+  {{/* Load community blox styles */}}
+  {{ $hb_community_styles := resources.Match "dist/community/blox/**.css" }}
+  {{ with $hb_community_styles }}
+    {{ $hb_community_styles = $hb_community_styles | resources.Concat "css/community-hugo-blox.css" }}
+    {{- if hugo.IsProduction -}}
+      {{- $hb_community_styles = $hb_community_styles | minify | fingerprint "sha256" -}}
+    {{- end -}}
+    <link href="{{ $hb_community_styles.RelPermalink }}" rel="stylesheet" />
+  {{ end }}
+
+  <script>
+    /* Hugo Blox JS Global Init */
+    window.hbb = {
+       defaultTheme: document.documentElement.dataset.wcThemeDefault,
+       setDarkTheme: () => {
+        document.documentElement.classList.add("dark");
+        document.documentElement.style.colorScheme = "dark";
+      },
+       setLightTheme: () => {
+        document.documentElement.classList.remove("dark");
+        document.documentElement.style.colorScheme = "light";
+      }
+    }
+
+    console.debug(`Default Hugo Blox Builder theme is ${window.hbb.defaultTheme}`);
+
+    if ("wc-color-theme" in localStorage) {
+      localStorage.getItem("wc-color-theme") === "dark" ? window.hbb.setDarkTheme() : window.hbb.setLightTheme();
+    } else {
+      window.hbb.defaultTheme === "dark" ? window.hbb.setDarkTheme() : window.hbb.setLightTheme();
+      if (window.hbb.defaultTheme === "system") {
+        window.matchMedia("(prefers-color-scheme: dark)").matches ? window.hbb.setDarkTheme() : window.hbb.setLightTheme();
+      }
+    }
+  </script>
+
+  <script>
+    // Apply Hugo style fixes
+    document.addEventListener('DOMContentLoaded', function () {
+      // Fix Hugo task list style
+      let checkboxes = document.querySelectorAll('li input[type=\'checkbox\'][disabled]');
+      checkboxes.forEach(e => {
+        e.parentElement.parentElement.classList.add('task-list');
+      });
+
+      // Fix Hugo missing <label> around checkbox and its text (fixes Lighthouse accessibility errors)
+      const liNodes = document.querySelectorAll('.task-list li');
+      liNodes.forEach(nodes => {
+        let textNodes = Array.from(nodes.childNodes).filter(node => node.nodeType === 3 && node.textContent.trim().length > 1);
+        if (textNodes.length > 0) {
+          const span = document.createElement('label');
+          textNodes[0].after(span);  // Use first text node as label
+          span.appendChild(nodes.querySelector('input[type=\'checkbox\']'));
+          span.appendChild(textNodes[0]);
+        }
+      });
+    });
+  </script>
+
+  {{/* Analytics & Verification */}}
+  {{/* !CACHED! All analytics and verification code is at site level */}}
+  {{ partialCached "blox-analytics/index" . }}
+
+  {{/* RSS Feed */}}
+  {{ with .OutputFormats.Get "RSS" }}
+    <link rel="alternate" href="{{ .RelPermalink }}" type="application/rss+xml" title="{{ site.Title }}" />
+  {{ end }}
+
+  {{/* Progressive Web App (PWA) Icon */}}
+  <link rel="icon" type="image/png" href="{{ (partial "functions/get_site_icon" 32).RelPermalink }}" />
+  <link rel="apple-touch-icon" type="image/png" href="{{ (partial "functions/get_site_icon" 180).RelPermalink }}" />
+
+  <link rel="canonical" href="{{ .Permalink }}" />
+
+  {{/* Get page image for sharing. */}}
+  {{ $sharing_image := resources.GetMatch (path.Join "media" "sharing.*") }}
+  {{ $featured_image := (.Resources.ByType "image").GetMatch "*featured*" }}
+  {{ $avatar_image := (.Resources.ByType "image").GetMatch "avatar*" }}
+  {{ $has_logo := fileExists "assets/media/logo.png" | or (fileExists "assets/media/logo.svg") }}
+  {{ $og_image := "" }}
+  {{ $twitter_card := "summary_large_image" }}
+  {{ if (and (eq .Kind "term") $avatar_image) }}
+    {{/* Match image processing in About widget to prevent generating more images than necessary. */}}
+    {{ $og_image = ($avatar_image.Fill "270x270 Center").Permalink }}
+    {{ $twitter_card = "summary" }}
+  {{ else if $featured_image }}
+    {{ $og_image = $featured_image.Permalink }}
+  {{ else if $sharing_image }}
+    {{ $og_image = $sharing_image.Permalink }}
+  {{ else if $has_logo }}
+    {{/* !CACHED! Can safely cache this site logo variant */}}
+    {{ $og_image = (partialCached "functions/get_logo" (dict "constraint" "fit" "size" 300)).Permalink }}
+    {{ $twitter_card = "summary" }}
+  {{ else }}
+    {{ $og_image = (partial "functions/get_site_icon" 512).Permalink }}
+    {{ $twitter_card = "summary" }}
+  {{ end }}
+  {{ $scr.Set "og_image" $og_image }}{{/* Set `og_image` globally for `rss.xml`. */}}
+
+  {{ $title := "" }}
+  {{ with .Params.seo.title }}
+    {{ $title = replace . "{brand}" site.Title }}
+  {{ else }}
+    {{ $title = .Title | default site.Title }}
+    {{ if ne $title site.Title }}{{ $title = printf "%s | %s" $title site.Title }}{{ end }}
+  {{ end }}
+  <meta property="twitter:card" content="{{ $twitter_card }}" />
+  {{ with site.Params.marketing.seo.twitter }}
+    <meta property="twitter:site" content="@{{ . }}" />
+    <meta property="twitter:creator" content="@{{ . }}" />
+  {{ end }}
+  <meta property="og:site_name" content="{{ site.Title }}" />
+  <meta property="og:url" content="{{ .Permalink }}" />
+  <meta property="og:title" content="{{ $title }}" />
+  <meta property="og:description" content="{{ $desc }}" />
+  {{- with $og_image -}}
+    <meta property="og:image" content="{{ . }}" />
+    <meta property="twitter:image" content="{{ . }}" />
+  {{- end -}}
+  <meta property="og:locale" content="{{ site.LanguageCode | default "en-us" }}" />
+  {{ if .IsPage }}
+    {{ if not .PublishDate.IsZero }}
+      <meta
+        property="article:published_time"
+        content="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}"
+      />
+    {{ else if not .Date.IsZero }}
+      <meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}" />
+    {{ end }}
+    {{ if not .Lastmod.IsZero }}<meta property="article:modified_time" content="{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">{{ end }}
+  {{ else }}
+    {{ if not .Date.IsZero }}
+      <meta property="og:updated_time" content="{{ .Date.Format "2006-01-02T15:04:05-07:00" | safeHTML }}" />
+    {{ end }}
+  {{ end }}
+
+  {{ partial "jsonld/main" (dict "page" . "summary" $desc) }}
+
+  <title>{{$title}}</title>
+
+  {{/* Load font theme */}}
+  {{ $font_family := "Inter var" }}
+  {{ $font_file := "" }}
+  {{ $font_type := "" }}
+  {{ if eq site.Params.appearance.font "serif" }}
+    {{ $font_file = "RobotoSlab-VariableFont_wght.ttf" }}
+    {{ $font_type = "truetype" }}
+  {{else}}
+    {{ $font_file = "Inter.var.woff2" }}
+    {{ $font_type = "woff2" }}
+  {{end}}
+  {{ $font := resources.Get (printf "dist/font/%s" $font_file) }}
+  <style>
+    @font-face {
+      font-family: '{{$font_family}}';
+      font-style: normal;
+      font-weight: 100 900;
+      font-display: swap;
+      src: url({{ $font.RelPermalink }}) format({{$font_type}});
+    }
+  </style>
+
+  {{ if .Params.design.background.image.filename }}
+    {{/* See Hugo note on linking assets in styles: https://github.com/gohugoio/hugoThemes#common-permalink-issues */}}
+    {{ $bg_img := resources.Get (printf "media/%s" .Params.design.background.image.filename) }}
+    {{ if $bg_img }}
+      {{/* Exception for SVG as Hugo doesn't yet support image processing on SVG. */}}
+      {{ if ne $bg_img.MediaType.SubType "svg" }}
+        {{ $bg_img = $bg_img.Fit "1920x1920 webp" }}
+      {{ end }}
+      <style>
+        #page-bg {
+         background-image: url('{{$bg_img.Permalink}}');
+         background-position: center;
+         background-size: cover;
+        }
+      </style>
+      {{ else }}
+        {{ errorf "Couldn't find page background `%s` in the `assets/media/` folder - please add it." .Params.design.background.image.filename }}
+      {{ end }}
+  {{ end }}
+
+  {{/* Init prior to auto-chunking/bundling scripts due to Hugo concurrency issues */}}
+  {{/* !CACHED! Initialized once at site level and then cached for each page */}}
+  {{- partialCached "init.html" . -}}
+
+  {{/* Load Third-Party Libraries */}}
+  {{ partial "libraries.html" . }}
+
+  {{ $js_license := printf "/*! Hugo Blox Builder Tailwind UI v%s | https://hugoblox.com/ */\n" site.Data.hugoblox.version }}
+  {{ $js_license := $js_license | printf "%s/*! Copyright 2016-present George Cushen (https://georgecushen.com/) */\n" }}
+  {{ $js_license := $js_license | printf "%s/*! License: https://github.com/HugoBlox/hugo-blox-builder/blob/main/LICENSE.md */\n" }}
+  {{ $js_bundle_head := $js_license | resources.FromString "js/bundle-head.js" }}
+  {{ $i18n := dict "copy" (i18n "btn_copy") "copied" (i18n "btn_copied" | default "Copied") }}
+  {{ $js_params := dict "hugoEnvironment" hugo.Environment "i18n" $i18n }}
+  {{ $js_academic := resources.Get "js/hb-code-copy.js" | js.Build (dict "targetPath" (printf "js/wow-core-%s.js" .Lang ) "params" $js_params) }}
+  {{ $js_academic := $js_academic | resources.Minify }}
+  {{- $js_theme := resources.Get "js/hb-theme.js" | resources.Minify -}}
+  {{- $js_lang := resources.Get "js/hb-i18n.js" | resources.Minify -}}
+  {{- $js_nav := resources.Get "js/hb-nav.js" | resources.Minify -}}
+  {{- $js_sidebar := resources.Get "js/hb-sidebar.js" | resources.Minify -}}
+  {{ $js_bundle := slice $js_bundle_head $js_academic $js_theme $js_lang $js_nav $js_sidebar | resources.Concat (printf "js/hugo-blox-%s.min.js" .Lang) }}
+  {{- if hugo.IsProduction -}}
+    {{ $js_bundle = $js_bundle | fingerprint "sha256" }}
+  {{- end -}}
+  <script
+    defer
+    src="{{ $js_bundle.RelPermalink }}"
+    integrity="{{ $js_bundle.Data.Integrity }}"
+  ></script>
+
+  {{/* EXTENSIBILITY HOOK: HEAD-END */}}
+  {{ partial "functions/get_hook" (dict "hook" "head-end" "context" .) }}
+</head>

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -1,0 +1,1 @@
+{{ partial "head.html" . }}


### PR DESCRIPTION
## Summary
- initialize dark theme before stylesheet loading to avoid flashes
- add custom SCSS to apply black background early
- hide theme chooser in navbar and document dark-only mode

## Testing
- `hugo --minify`
- `vale .`


------
https://chatgpt.com/codex/tasks/task_e_689efc1c23988322846fef304c454e16