### PR TITLE
chore(ci): lint docs with vale

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: errata-ai/vale-action@v2
         with:
           config: .vale.ini
+          files: .

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The site loads in dark mode by default, and you can switch themes from the heade
 
 Install the extended version of Hugo and run:
 
-```bash
+```shell
 hugo server
 ```
 
-The site will be served at `http://localhost:1313`.
+The site runs at `http://localhost:1313`.
 
 ## Linting
 
-[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles. Run `vale sync` once to download the external packages, then `vale .` before committing. The workflow runs on each push and pull request.
+[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles. Run `vale sync` once to download the external packages, then `vale .` before committing. The workflow runs on each push and pull request, linting all Markdown files in `content/` and the root README.
 
 ## Deployment
 
@@ -24,5 +24,5 @@ Commits to `main` deploy to GitHub Pages via the included workflow.
 
 ## Funding
 
-The server runs at home and the costs come out of pocket. Help keep it running at <https://ko-fi.com/goingdark>.
+The server runs at home, and we cover the costs personally. Help keep it running at <https://ko-fi.com/goingdark>.
 


### PR DESCRIPTION
## Summary
- run Vale across the whole repository including docs
- clarify lint instructions and clean up README wording

## Testing
- `vale README.md`
- `vale content/docs/overview/about.md` *(fails: Spelling check "privacy-focused"?)*

------
https://chatgpt.com/codex/tasks/task_e_689fb278903083229661f26a28ab3e55