### PR TITLE
docs: clarify bot account policy

### DIFF
--- a/content/policy/automated-bot-accounts.md
+++ b/content/policy/automated-bot-accounts.md
@@ -9,27 +9,27 @@ pager: false
 ## People first
 
 Going Dark exists for people, not automated feeds.
-We want timelines filled with human voices, real conversations, and personal updates — not endless reposts or algorithmic noise.
+Timelines should feature human voices, real conversations, and personal updates, not endless re-shares or algorithmic noise.
 
-Because of that, automated and bot accounts are generally not allowed here.
-If you create one without prior approval, it will be suspended without notice.
+Therefore, automated and bot accounts are not allowed here.
+Creating one without prior approval results in suspension without notice.
 
 ## Rare exceptions
 
-We may make a rare exception if someone proposes a bot that:
+A rare exception exists if someone proposes a bot that:
 
-- Clearly benefits our community’s focus on privacy, self-hosting, open-source, or related topics.
+- Benefits the community’s focus on privacy, self hosting, open source, or related topics.
 - Doesn’t take over timelines or flood notifications.
 - Adds genuine value without replacing human interaction.
 
-All exceptions are decided case-by-case by the admin.
+The admin decides each exception case by case.
 
 ## Minimum requirements for approval
 
 ### 1. Owner must be part of the community
 
-The bot’s operator must have their own personal account here.
-They must be active enough that we can easily reach them and they can see how their bot is received.
+The bot’s operator must have a personal account here.
+They must stay active so contact is easy and they can gauge how others react to the bot.
 
 ### 2. Clear labeling
 
@@ -38,9 +38,9 @@ If replies aren’t read, the profile bio must say “Unmonitored account”.
 
 ### 3. Posting limits
 
-Most posts should be Unlisted unless responding directly to someone.
-Public posting requires explicit approval and will be revoked if abused.
-Post infrequently — think occasional updates, not a constant feed.
+Post most content as Unlisted unless responding directly to someone.
+Public posting requires explicit approval; misuse revokes it.
+Post infrequently; think occasional updates, not a constant feed.
 
 ### 4. Interaction style
 
@@ -50,18 +50,18 @@ No unsolicited mass mentions or follow sprees.
 ### 5. Content rules
 
 Must follow all server rules and community guidelines.
-No crossposting that mirrors entire feeds from corporate platforms (Twitter/X, Facebook, Instagram) without adapting for the Fediverse.
-No link-dumps or engagement bait.
+No cross-posting that mirrors entire feeds from corporate platforms (Twitter/X, Facebook, Instagram) without adapting for the Fediverse.
+No link dumps or engagement bait.
 
-### 6. Auto-cleanup
+### 6. Automatic cleanup
 
-Set the account to automatically delete old posts after a set period (recommended: 1 year).
-Keep pinned and interacted-with posts.
+Set the account to automatically delete old posts after a set time (recommended: 1 year).
+Keep pinned posts and those with interactions.
 
 ### 7. Operator responsibility
 
-A reachable human must monitor reports and address issues promptly.
-If the bot misbehaves or causes moderation load, approval can be revoked immediately.
+A reachable human must review reports and handle issues quickly.
+If the bot misbehaves or creates extra moderation work, the admin may revoke approval at once.
 
 ## Requesting approval
 
@@ -72,11 +72,11 @@ Before creating the account, send a short proposal to the admin account includin
 - Posting schedule and frequency.
 - How you’ll ensure it stays compliant with the above rules.
 
-We’ll reply with either:
+The admin replies with one of the following:
 
-- Approved – you can create the bot under the agreed rules.
-- Changes required – adjust your proposal before approval.
-- Declined – it’s not a fit for this server.
+- Approved: create the bot under the agreed rules.
+- Changes required: adjust your proposal before approval.
+- Declined: it's not a fit for this server.
 
 ## Enforcement
 
@@ -84,10 +84,10 @@ Unapproved bots: suspended without notice.
 
 Approved bots breaking rules: one warning, then silence or suspension.
 
-Remote bots from other servers: may be silenced or blocked if they’re noisy, spammy, or harm federation health.
+Remote bots from other servers can be silenced or blocked if they’re noisy, spam-like, or harm federation health.
 
 ## Final note
 
-We love creativity and automation when it’s in service of people, not at their expense.
-If in doubt, ask first — it’s always easier to approve a bot before it’s running than to clean up after one that’s causing trouble.
+Creativity and automation are welcome when they serve people, not at their expense.
+If in doubt, ask first; approving a bot before it runs is easier than cleaning up after one that causes trouble.
 

--- a/content/policy/index.md
+++ b/content/policy/index.md
@@ -8,5 +8,5 @@ pager: false
 
 ## Policies
 
-- [Automated and Bot Accounts Policy](./automated-bot-accounts/)
+- [Automated and Bot Accounts Policy](automated-bot-accounts/)
 


### PR DESCRIPTION
## Summary
- fix policy index link
- refine automated bot account policy wording and style

## Testing
- `vale content/policy/index.md content/policy/automated-bot-accounts.md` *(fails: command not found)*
- `/home/runner/reviewdog -f=rdjsonl -name=vale -reporter=github-pr-annotations -fail-on-error=false -filter-mode=added -level=info` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe7490248322b228bdc55185568d