### PR TITLE
chore: add pre-commit config for Vale

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: vale
+        name: vale
+        entry: vale
+        language: system
+        types: [markdown]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ The site runs at `http://localhost:1313`.
 
 ## Linting
 
-[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles. Run `vale sync` once to download the external packages, then `vale .` before committing. The workflow runs on each push and pull request, linting all Markdown files in `content/` and the root README.
+[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles.
+
+1. Run `vale sync` once to download the external packages.
+2. Install the `pre-commit` tool with `pre-commit install`.
+3. It runs `vale` on staged Markdown files.
+
+Use `pre-commit run --files path/to/file.md` to lint a file manually. The workflow still lints all Markdown files in `content/` and the root README on each push and pull request.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- run Vale with pre-commit on staged Markdown
- document pre-commit workflow for linting

## Testing
- `pre-commit run --files README.md`
- `hugo --minify` *(fails: can't evaluate field Defer in type interface)*

------
https://chatgpt.com/codex/tasks/task_e_689fc195401c8322a15c8680f8b3aa2f