### PR TITLE
docs: resolve style warnings

### DIFF
--- a/.vale/alex/README.md
+++ b/.vale/alex/README.md
@@ -1,4 +1,4 @@
-Based on [alex](https://github.com/get-alex/alex).
+Based on [Alex](https://github.com/get-alex/alex).
 
 > Catch insensitive, inconsiderate writing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Going Dark Wiki
+# Going dark wiki
 
 Community wiki for [goingdark.social](https://goingdark.social).
 Built with [Hugo](https://gohugo.io) and the Hugo Blox documentation theme.
@@ -8,11 +8,11 @@ The site loads in dark mode by default, and you can switch themes from the heade
 
 Install the extended version of Hugo and run:
 
-```bash
+```shell
 hugo server
 ```
 
-The site will be served at `http://localhost:1313`.
+Hugo serves the site at `http://localhost:1313`.
 
 ## Linting
 
@@ -24,5 +24,5 @@ Commits to `main` deploy to GitHub Pages via the included workflow.
 
 ## Funding
 
-The server runs at home and the costs come out of pocket. Help keep it running at <https://ko-fi.com/goingdark>.
+The server runs at home, and its owner covers the costs. Help keep it running at <https://ko-fi.com/goingdark>.
 


### PR DESCRIPTION
## Summary
- adjust README heading to sentence case and remove cliché phrasing
- capitalize Alex in Vale plugin README

## Testing
- `vale README.md .vale/alex/README.md`
- `hugo --minify` *(fails: Module "github.com/HugoBlox/hugo-blox-builder/modules/blox-tailwind" requires Hugo >= 0.134.1)*

------
https://chatgpt.com/codex/tasks/task_e_689f9fcd81308322aacb0364be58b3c4