### PR TITLE
chore: ignore legal docs in Vale

### DIFF
--- a/.valeignore
+++ b/.valeignore
@@ -1,2 +1,3 @@
 LICENSE.md
 hugo-blox/**
+content/docs/legal/**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The site runs at `http://localhost:1313`.
 
 ## Linting
 
-[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles.
+[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles. Docs in `content/docs/legal/` are excluded.
 
 1. Run `vale sync` once to download the external packages.
 2. Install the `pre-commit` tool with `pre-commit install`.


### PR DESCRIPTION
## Summary
- exclude legal documentation from Vale checks
- note Vale exclusion for legal docs in README

## Testing
- `pre-commit run --files README.md .valeignore` *(fails: Executable `vale` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11edc6e048322b4e14cdd5e1b63af