### PR TITLE
docs: clarify appeals process

### DIFF
--- a/content/docs/legal/terms-of-service.md
+++ b/content/docs/legal/terms-of-service.md
@@ -63,7 +63,7 @@ We enforce our rules using a mix of automated anti-spam and abuse filters, block
 
 ## Appeals
 
-If your content or account is restricted, you may ask for a review by emailing **[support@goingdark.social](mailto:support@goingdark.social)** from your account email. We handle appeals in a timely, objective, and non-discriminatory way. During review, temporary safeguards may remain in place if needed to protect the service.
+If your content or account is restricted, you may ask for a review through the website at goingdark.social. We handle appeals in a timely, objective, and non-discriminatory way. During review, temporary safeguards may remain in place if needed to protect the service.
 
 ## Automated access and research
 

--- a/content/docs/policies/moderation-guidelines.md
+++ b/content/docs/policies/moderation-guidelines.md
@@ -29,5 +29,5 @@ Email notifications are sent for each action.
 
 ### Appeals
 
-An appeal can be filed in 14 days by emailing contact@goingdark.social. Responses arrive in 14 days. Decisions after the appeal are final.
+An appeal can be filed in 14 days through the website at goingdark.social. Responses arrive in 14 days. Decisions after the appeal are final.
 


### PR DESCRIPTION
## Summary
- direct moderation appeals through goingdark.social instead of email
- note website-based review in terms of service

## Testing
- `pre-commit run --files content/docs/policies/moderation-guidelines.md content/docs/legal/terms-of-service.md` *(fails: Vale style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1211b571c8322b1eb26bc4d34aee6