### PR TITLE
docs: restructure rules and move bot policy

### DIFF
--- a/content/docs/community/community-guidelines.md
+++ b/content/docs/community/community-guidelines.md
@@ -35,7 +35,7 @@ The following are not allowed, and may lead to moderation actions:
 - **Misinformation that causes harm.** False or misleading claims that may endanger health, safety, or public trust.  
 - **Pornography and sex work promotion.** Explicit sexual content and solicitation are not permitted here.  
 - **Untagged sensitive media.** Nudity, gore, or graphic violence must always be behind a content warning.  
-- **Automated posting without approval.** Bots must follow the [Bot Policy](/docs/policies/bots-and-automation/). Unapproved bots are suspended.  
+- **Automated posting without approval.** Bots must follow the [Bot Policy](/docs/policies/rules/bots/). Unapproved bots are suspended.  
 - **Illegal content.** Anything illegal under EU or Swedish law, including CSAM, extremist propaganda, and incitement to violence.  
 - **Disruptive use.** Flooding timelines, excessive posting, mass unsolicited mentions, or degrading server performance.  
 

--- a/content/docs/policies/_index.md
+++ b/content/docs/policies/_index.md
@@ -6,6 +6,5 @@ weight: 20
   {{< card url="bots-and-automation/" title="Bots and automation" icon="bug-ant" subtitle="Rules for automated accounts" >}}
   {{< card url="federation-policy/" title="Federation policy" icon="globe-alt" subtitle="How we choose who to federate with" >}}
   {{< card url="moderation-guidelines/" title="Moderation guidelines" icon="hand-raised" subtitle="How moderation decisions are made" >}}
-  {{< card url="rules/" title="Rules" icon="clipboard-document-check" subtitle="Code of conduct for the community" >}}
+  {{< card url="rules/index/" title="Rules" icon="clipboard-document-check" subtitle="Code of conduct for the community" >}}
 {{< /cards >}}
-

--- a/content/docs/policies/bots-and-automation.md
+++ b/content/docs/policies/bots-and-automation.md
@@ -1,93 +1,18 @@
 ---
 title: Automated and Bot Accounts Policy
+aliases:
+  - /docs/policies/rules/bots/
+  - /docs/policies/rules/13_bots/
 weight: 10
-toc: true
+toc: false
 reading_time: false
 pager: false
 ---
 
-## People first
+This document has moved.
 
-Going Dark exists for people, not automated feeds.
-Timelines should feature human voices, real conversations, and personal updates, not endless re-shares or algorithmic noise.
+The canonical bot policy lives at **/docs/policies/rules/bots/**.
 
-Therefore, automated and bot accounts are not allowed here.
-Creating one without prior approval results in suspension without notice.
+If you were sent here by an old link, you will find the current version at:
 
-## Rare exceptions
-
-A rare exception exists if someone proposes a bot that:
-
-- Benefits the community’s focus on privacy, self hosting, open source, or related topics.
-- Doesn’t take over timelines or flood notifications.
-- Adds genuine value without replacing human interaction.
-
-The admin decides each exception case by case.
-
-## Minimum requirements for approval
-
-### 1. Owner must be part of the community
-
-The bot’s operator must have a personal account here.
-They must stay active so contact is easy and they can gauge how others react to the bot.
-
-### 2. Clear labeling
-
-Enable Mastodon’s “This is an automated account” setting.
-If replies aren’t read, the profile bio must say “Unmonitored account”.
-
-### 3. Posting limits
-
-Post most content as Unlisted unless responding directly to someone.
-Public posting requires explicit approval; misuse revokes it.
-Post infrequently; think occasional updates, not a constant feed.
-
-### 4. Interaction style
-
-Prefer posting only in response to direct interaction (mentions, keywords, commands).
-No unsolicited mass mentions or follow sprees.
-
-### 5. Content rules
-
-Must follow all server rules and community guidelines.
-No cross-posting that mirrors entire feeds from corporate platforms (Twitter/X, Facebook, Instagram) without adapting for the Fediverse.
-No link dumps or engagement bait.
-
-### 6. Automatic cleanup
-
-Set the account to automatically delete old posts after a set time (recommended: 1 year).
-Keep pinned posts and those with interactions.
-
-### 7. Operator responsibility
-
-A reachable human must review reports and handle issues quickly.
-If the bot misbehaves or creates extra moderation work, the admin may revoke approval at once.
-
-## Requesting approval
-
-Before creating the account, send a short proposal to the admin account including:
-
-- Purpose and value to our community.
-- Example posts or expected format.
-- Posting schedule and frequency.
-- How you’ll ensure it stays compliant with the above rules.
-
-The admin replies with one of the following:
-
-- Approved: create the bot under the agreed rules.
-- Changes required: adjust your proposal before approval.
-- Declined: it's not a fit for this server.
-
-## Enforcement
-
-Unapproved bots: suspended without notice.
-
-Approved bots breaking rules: one warning, then silence or suspension.
-
-Remote bots from other servers can be silenced or blocked if they’re noisy, spam-like, or harm federation health.
-
-## Final note
-
-Creativity and automation are welcome when they serve people, not at their expense.
-If in doubt, ask first; approving a bot before it runs is easier than cleaning up after one that causes trouble.
-
+**[Bot Policy](/docs/policies/rules/bots/)**.

--- a/content/docs/policies/rules.md
+++ b/content/docs/policies/rules.md
@@ -1,19 +1,17 @@
 ---
-title: Rules
+title: Rules - moved
+aliases:
+  - /docs/policies/rules/index/
+  - /docs/policies/rules/index.html
+  - /docs/policies/rules/
 weight: 40
-toc: true
+toc: false
 reading_time: false
-pager: true
+pager: false
 ---
 
-- Treat people well.
-- Use content warnings when a post might upset or surprise others.
-- Keep public areas safe for work.
-- No illegal content or solicitations.
-- No spam or automated promotion.
-- No hate, threats, or harassment.
-- Don't game the rules or look for loopholes.
-- Be honest about who you are.
+This page moved to a dedicated section with per-rule pages and links.
 
-Breaking rules may lead to moderation action. Appeals are handled as described in our [Moderation Guidelines](/docs/policies/moderation-guidelines/#appeals).
+Go to **[Rules](/docs/policies/rules/index/)**.
 
+For bots and automation, see **[Bot Policy](/docs/policies/rules/bots/)**.

--- a/content/docs/policies/rules/01_treat-people-well.md
+++ b/content/docs/policies/rules/01_treat-people-well.md
@@ -1,0 +1,21 @@
+---
+title: Rule 1 - Treat people well
+weight: 1
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Talk to others the way you would want to be talked to. Disagree without hostility.
+
+**Why:** This server is small on purpose. We keep it human sized, so tone matters.
+
+**Do:**
+- Assume good faith. Ask before judging.
+- Use CWs when a topic might upset or surprise others.
+
+**Do not:**
+- Insult, belittle, or bait people.
+- Dogpile or brigade.
+
+**Enforcement:** Breaches may lead to a warning, limit, or suspension per the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Report issues via the in-app report or at [abuse@goingdark.social](mailto:abuse@goingdark.social). See [Reporting](/docs/user/reporting/).

--- a/content/docs/policies/rules/02_content-warnings.md
+++ b/content/docs/policies/rules/02_content-warnings.md
@@ -1,0 +1,19 @@
+---
+title: Rule 2 - Use content warnings when needed
+weight: 2
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Put sensitive or potentially upsetting material behind a Content Warning.
+
+**Examples that often need a CW:** nudity, gore, graphic violence, politics, electioneering, major news spoilers, disturbing imagery, common phobias.
+
+**Tips:**
+- Keep the CW headline short and descriptive.
+- If unsure, add a CW. People can opt in to view.
+
+**Do not:** use CWs to hide abuse or evade moderation.
+
+**Enforcement:** Posts may be limited or removed. Repeated issues can lead to account actions per the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Report concerns via the report tool or [abuse@goingdark.social](mailto:abuse@goingdark.social).

--- a/content/docs/policies/rules/03_keep-it-clean.md
+++ b/content/docs/policies/rules/03_keep-it-clean.md
@@ -1,0 +1,15 @@
+---
+title: Rule 3 - Keep it clean
+weight: 3
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Gratuitous obscenity that adds nothing to a discussion is not welcome.
+
+**Allowed:** normal swearing in context, adult humor with a CW, good faith discussion.
+
+**Not allowed:** obscene slurs, shock content, or graphic sexual content in public timelines.
+
+**Enforcement:** Content can be limited or removed. Repeated issues can lead to stronger actions per the [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/04_no-illegal-content.md
+++ b/content/docs/policies/rules/04_no-illegal-content.md
@@ -1,0 +1,11 @@
+---
+title: Rule 4 - No illegal content
+weight: 4
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Do not post anything illegal under EU or Swedish law. This includes CSAM, extremist propaganda, and incitement to violence.
+
+**Enforcement:** Immediate removal and suspension. We comply with valid legal orders. See [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/05_no-spam.md
+++ b/content/docs/policies/rules/05_no-spam.md
@@ -1,0 +1,16 @@
+---
+title: Rule 5 - No spam
+weight: 5
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** No spam accounts, link dumping, engagement bait, or using the server as an ad platform.
+
+**Examples:**
+- Mass unsolicited mentions.
+- Repetitive link posts without context.
+- Commercial promos that drown out conversation.
+
+**Enforcement:** Limit, silence, or suspension per the [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/06_no-hate-or-threats.md
+++ b/content/docs/policies/rules/06_no-hate-or-threats.md
@@ -1,0 +1,13 @@
+---
+title: Rule 6 - No hate or threats
+weight: 6
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** No hate speech, abusive, or threatening behavior.
+
+**Examples include:** attacks based on gender, nationality, religion, race, age, sexual identity, disability, or similar. Pizza topping wars are fine. Hate on systemd all you want.
+
+**Enforcement:** Warning or immediate suspension for serious cases, as per the [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/07_no-loopholes.md
+++ b/content/docs/policies/rules/07_no-loopholes.md
@@ -1,0 +1,11 @@
+---
+title: Rule 7 - Do not look for loopholes
+weight: 7
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** If it clearly goes against the spirit of the rules, do not do it even if it is not named explicitly.
+
+**Enforcement:** Actions are proportionate and explained in a statement of reasons. See [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/08_consequences.md
+++ b/content/docs/policies/rules/08_consequences.md
@@ -1,0 +1,11 @@
+---
+title: Rule 8 - Breaking rules has consequences
+weight: 8
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Violations can lead to a warning, limit, silencing, or permanent suspension. Severe cases may skip steps.
+
+**Appeals:** You can appeal as described in the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Use in-app reports or email [abuse@goingdark.social](mailto:abuse@goingdark.social).

--- a/content/docs/policies/rules/09_honest-identity.md
+++ b/content/docs/policies/rules/09_honest-identity.md
@@ -1,0 +1,13 @@
+---
+title: Rule 9 - Be honest about identity
+weight: 9
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Do not impersonate a person or brand without a clear indication that the account is unofficial or parody.
+
+**Allowed:** parody and commentary accounts with clear labeling.
+
+**Enforcement:** Content removal or account actions per the [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/10_respect-server.md
+++ b/content/docs/policies/rules/10_respect-server.md
@@ -1,0 +1,13 @@
+---
+title: Rule 10 - Respect the server and its users
+weight: 10
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Do not try to disrupt, hack, scrape at scale, or damage goingdark.social or its community.
+
+**Examples:** DDoS, token brute forcing, bypassing rate limits, automated scraping that harms stability.
+
+**Enforcement:** Limits or suspension. Serious cases reported to relevant authorities. See [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/11_no-doxing.md
+++ b/content/docs/policies/rules/11_no-doxing.md
@@ -1,0 +1,11 @@
+---
+title: Rule 11 - No doxing
+weight: 11
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Do not share private information about someone without their consent. This includes real names if not public, addresses, phone numbers, emails, and other identifying data.
+
+**Enforcement:** Removal and account action per the [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/12_stop-means-stop.md
+++ b/content/docs/policies/rules/12_stop-means-stop.md
@@ -1,0 +1,13 @@
+---
+title: Rule 12 - Stop means stop
+weight: 12
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** If someone asks you to stop engaging with them, stop.
+
+**Examples:** stop replying, stop mentioning, stop tagging. Respect blocks and mutes.
+
+**Enforcement:** Warnings or limits. Repeated behavior may lead to suspension. See [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/13_bots.md
+++ b/content/docs/policies/rules/13_bots.md
@@ -1,0 +1,12 @@
+---
+title: Automated and Bot Accounts Policy
+aliases:
+  - /docs/policies/bots-and-automation/
+  - /docs/policies/rules/botpolicy/
+weight: 13
+toc: true
+reading_time: false
+pager: true
+---
+
+{{< readfile file="/content/docs/policies/rules/_bots-body.md" >}}

--- a/content/docs/policies/rules/14_no-calls-for-violence.md
+++ b/content/docs/policies/rules/14_no-calls-for-violence.md
@@ -1,0 +1,11 @@
+---
+title: Rule 14 - No calls for violence
+weight: 14
+toc: true
+reading_time: false
+pager: true
+---
+
+**Plain rule:** Do not promote or encourage harm toward anyone or any group.
+
+**Enforcement:** Immediate removal and possible suspension per the [Moderation Guidelines](/docs/policies/moderation-guidelines/).

--- a/content/docs/policies/rules/_bots-body.md
+++ b/content/docs/policies/rules/_bots-body.md
@@ -1,0 +1,72 @@
+## People first
+
+Going Dark exists for people, not automated feeds. Timelines should feature human voices, real conversations, and personal updates, not endless re-shares or algorithmic noise.
+
+Therefore, automated and bot accounts are not allowed here. Creating one without prior approval results in suspension without notice.
+
+## Rare exceptions
+
+A rare exception exists if someone proposes a bot that:
+
+- Benefits the community focus on privacy, self hosting, open source, or related topics.
+- Does not take over timelines or flood notifications.
+- Adds genuine value without replacing human interaction.
+
+The admin decides each exception case by case.
+
+## Minimum requirements for approval
+
+### 1. Owner must be part of the community
+
+The bot operator must have a personal account here. They must stay active so contact is easy and they can gauge how others react to the bot.
+
+### 2. Clear labeling
+
+Enable Mastodon settings for automated accounts. If replies are not read, the profile bio must say Unmonitored account.
+
+### 3. Posting limits
+
+Post most content as Unlisted unless responding directly to someone. Public posting requires explicit approval. Misuse revokes it. Post infrequently. Think occasional updates, not a constant feed.
+
+### 4. Interaction style
+
+Prefer posting only in response to direct interaction. No unsolicited mass mentions or follow sprees.
+
+### 5. Content rules
+
+Must follow all server rules and community guidelines. No cross-posting that mirrors entire feeds from corporate platforms without adapting for the Fediverse. No link dumps or engagement bait.
+
+### 6. Automatic cleanup
+
+Set the account to automatically delete old posts after a set time, recommended 1 year. Keep pinned posts and those with interactions.
+
+### 7. Operator responsibility
+
+A reachable human must review reports and handle issues quickly. If the bot misbehaves or creates extra moderation work, the admin may revoke approval at once.
+
+## Requesting approval
+
+Before creating the account, send a short proposal to the admin account including:
+
+- Purpose and value to our community.
+- Example posts or expected format.
+- Posting schedule and frequency.
+- How you will ensure it stays compliant with the above rules.
+
+The admin replies with one of the following:
+
+- Approved: create the bot under the agreed rules.
+- Changes required: adjust your proposal before approval.
+- Declined: it is not a fit for this server.
+
+## Enforcement
+
+Unapproved bots: suspended without notice.
+
+Approved bots breaking rules: one warning, then silence or suspension.
+
+Remote bots from other servers can be silenced or blocked if they are noisy, spam like, or harm federation health.
+
+## Final note
+
+Creativity and automation are welcome when they serve people, not at their expense. If in doubt, ask first. Approving a bot before it runs is easier than cleaning up after one that causes trouble.

--- a/content/docs/policies/rules/index.md
+++ b/content/docs/policies/rules/index.md
@@ -1,0 +1,47 @@
+---
+title: Rules
+weight: 40
+toc: true
+reading_time: false
+pager: true
+---
+
+> Canonical source: the rules shown on the instance about page control. This wiki explains context. If there is any mismatch, the instance copy takes precedence.
+
+## The Rules
+
+1. **Treat people well**  
+   [Read more](/docs/policies/rules/01_treat-people-well/)
+2. **Use content warnings when needed**  
+   [Read more](/docs/policies/rules/02_content-warnings/)
+3. **Keep it clean**  
+   [Read more](/docs/policies/rules/03_keep-it-clean/)
+4. **No illegal content**  
+   [Read more](/docs/policies/rules/04_no-illegal-content/)
+5. **No spam**  
+   [Read more](/docs/policies/rules/05_no-spam/)
+6. **No hate or threats**  
+   [Read more](/docs/policies/rules/06_no-hate-or-threats/)
+7. **Do not look for loopholes**  
+   [Read more](/docs/policies/rules/07_no-loopholes/)
+8. **Breaking rules has consequences**  
+   [Read more](/docs/policies/rules/08_consequences/)
+9. **Be honest about identity**  
+   [Read more](/docs/policies/rules/09_honest-identity/)
+10. **Respect the server and its users**  
+    [Read more](/docs/policies/rules/10_respect-server/)
+11. **No doxing**  
+    [Read more](/docs/policies/rules/11_no-doxing/)
+12. **Stop means stop**  
+    [Read more](/docs/policies/rules/12_stop-means-stop/)
+13. **No unapproved bots**  
+    Go directly to the **[Bot Policy](/docs/policies/rules/bots/)**.
+14. **No calls for violence**  
+    [Read more](/docs/policies/rules/14_no-calls-for-violence/)
+
+---
+
+See also:  
+- [Community Guidelines](/docs/community/community-guidelines/) for culture and examples.  
+- [Moderation Guidelines](/docs/policies/moderation-guidelines/) for actions and appeals.  
+- [Reporting](/docs/user/reporting/) to report problems.

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -1,0 +1,2 @@
+{{ $path := .Get "file" }}
+{{ readFile $path | markdownify }}


### PR DESCRIPTION
## Summary
- reorganize rules into a dedicated section with per-rule pages
- move bot policy under rules and keep aliases for old URLs
- add shortcode to embed shared bot policy text

## Testing
- `pre-commit run --files content/docs/policies/bots-and-automation.md content/docs/policies/rules.md content/docs/policies/_index.md content/docs/community/community-guidelines.md content/docs/policies/rules/index.md content/docs/policies/rules/01_treat-people-well.md content/docs/policies/rules/02_content-warnings.md content/docs/policies/rules/03_keep-it-clean.md content/docs/policies/rules/04_no-illegal-content.md content/docs/policies/rules/05_no-spam.md content/docs/policies/rules/06_no-hate-or-threats.md content/docs/policies/rules/07_no-loopholes.md content/docs/policies/rules/08_consequences.md content/docs/policies/rules/09_honest-identity.md content/docs/policies/rules/10_respect-server.md content/docs/policies/rules/11_no-doxing.md content/docs/policies/rules/12_stop-means-stop.md content/docs/policies/rules/13_bots.md content/docs/policies/rules/_bots-body.md content/docs/policies/rules/14_no-calls-for-violence.md` *(fails: multiple style and spelling errors)*
- `vale sync`
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68a1f8d2d0e08322a536655ac183a186