### PR TITLE
fix(docs): convert rules folder to branch

### DIFF
--- a/content/docs/policies/rules/_index.md
+++ b/content/docs/policies/rules/_index.md
@@ -8,7 +8,7 @@ pager: true
 
 > Canonical source: the rules shown on the instance about page control. This wiki explains context. If there is any mismatch, the instance copy takes precedence.
 
-## The Rules
+## The rules
 
 1. **Treat people well**  
    [Read more](/docs/policies/rules/01_treat-people-well/)
@@ -22,7 +22,7 @@ pager: true
    [Read more](/docs/policies/rules/05_no-spam/)
 6. **No hate or threats**  
    [Read more](/docs/policies/rules/06_no-hate-or-threats/)
-7. **Do not look for loopholes**  
+7. **Don't look for loopholes**  
    [Read more](/docs/policies/rules/07_no-loopholes/)
 8. **Breaking rules has consequences**  
    [Read more](/docs/policies/rules/08_consequences/)
@@ -30,7 +30,7 @@ pager: true
    [Read more](/docs/policies/rules/09_honest-identity/)
 10. **Respect the server and its users**  
     [Read more](/docs/policies/rules/10_respect-server/)
-11. **No doxing**  
+11. **No sharing personal information**  
     [Read more](/docs/policies/rules/11_no-doxing/)
 12. **Stop means stop**  
     [Read more](/docs/policies/rules/12_stop-means-stop/)


### PR DESCRIPTION
## Summary
- rename `content/docs/policies/rules/index.md` to `_index.md` so Hugo publishes child rule pages
- tweak rule list wording for style lint

## Testing
- `pre-commit run --files content/docs/policies/rules/_index.md`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a21a4b74288322acbf458cb01fa528