### PR TITLE
docs: summarize rules and clarify policy text

### DIFF
--- a/content/docs/legal/_index.md
+++ b/content/docs/legal/_index.md
@@ -6,6 +6,6 @@ weight: 60
   {{< card url="privacy/" title="Privacy" icon="lock-closed" subtitle="What data we collect and how long we keep it" >}}
 {{< /cards >}}
 {{< cards >}}
-  {{< card url="terms-of-service/" title="Terms of Service" icon="lock-closed" subtitle="What data we collect and how long we keep it" >}}
+  {{< card url="terms-of-service/" title="Terms of Service" icon="scale" subtitle="Rules for using the service" >}}
 {{< /cards >}}
 

--- a/content/docs/operations/backup-and-restore.md
+++ b/content/docs/operations/backup-and-restore.md
@@ -8,9 +8,9 @@ pager: true
 
 ### What's backed up
 
-- PostgreSQL databases.
-- Media stored in R2.
-- Configuration files is running from git.
+- PostgreSQL databases
+- Media stored in R2
+- Configuration files live in Git
 
 ### Schedule and retention
 

--- a/content/docs/operations/hosting-architecture.md
+++ b/content/docs/operations/hosting-architecture.md
@@ -16,5 +16,5 @@ goingdark.social runs on Talos-managed Kubernetes.
 
 Public endpoints are the web interface and API. Internal services stay on private networks.
 
-Our server is currently running on hardware in my home. This works decent but has some cons. Until we see justifications of moving it with donations atleast covering 3 months of uptime on a provider. This is to ensure that we wont need to shutdown in the future due to lack of funds.
+The server runs on home hardware. It works reasonably well but has tradeoffs. A move to a provider happens when donations cover at least three months of costs to avoid any shutdown risk due to lack of funds.
 

--- a/content/docs/operations/shutdown-procedure.md
+++ b/content/docs/operations/shutdown-procedure.md
@@ -6,7 +6,7 @@ reading_time: false
 pager: true
 ---
 
-While we dont plan to shutdown we want to be transparent that things might change. Therefore we are looking to ensure that we are not the single point of failure. 
+The team doesn't plan to shut down, but things might change. The goal is to avoid a single point of failure.
 
 If the service ever shuts down:
 

--- a/content/docs/policies/rules/_index.md
+++ b/content/docs/policies/rules/_index.md
@@ -8,35 +8,49 @@ pager: true
 
 > Canonical source: the rules shown on the instance about page control. This wiki explains context. If there is any mismatch, the instance copy takes precedence.
 
-## The rules
+## The Rules
 
-1. **Treat people well**  
+1. **Treat people well**
+   Plain rule: Talk to others how you want to be treated. Disagree without hostility.
    [Read more](/docs/policies/rules/01_treat-people-well/)
-2. **Use content warnings when needed**  
+2. **Use content warnings when needed**
+   Plain rule: Put sensitive or upsetting material behind a Content Warning.
    [Read more](/docs/policies/rules/02_content-warnings/)
-3. **Keep it clean**  
+3. **Keep it clean**
+   Plain rule: Gratuitous obscenity that adds nothing to a discussion isn't welcome.
    [Read more](/docs/policies/rules/03_keep-it-clean/)
-4. **No illegal content**  
+4. **No illegal content**
+   Plain rule: Don't post anything illegal under EU or Swedish law.
    [Read more](/docs/policies/rules/04_no-illegal-content/)
 5. **No spam**  
+   Plain rule: No spam accounts, link dumping, engagement bait, or using the server as an ad platform.  
    [Read more](/docs/policies/rules/05_no-spam/)
 6. **No hate or threats**  
+   Plain rule: No hate speech, abusive, or threatening behavior.  
    [Read more](/docs/policies/rules/06_no-hate-or-threats/)
-7. **Don't look for loopholes**  
+7. **Don't look for loopholes**
+   Plain rule: If something goes against the spirit of the rules, don't do it even if it's not named.
    [Read more](/docs/policies/rules/07_no-loopholes/)
-8. **Breaking rules has consequences**  
+8. **Breaking rules has consequences**
+   Plain rule: Violations can lead to a warning, limit, silencing, or permanent suspension; severe cases can skip steps.
    [Read more](/docs/policies/rules/08_consequences/)
-9. **Be honest about identity**  
+9. **Be honest about identity**
+   Plain rule: Don't impersonate a person or brand without a clear indication the account is unofficial or parody.
    [Read more](/docs/policies/rules/09_honest-identity/)
-10. **Respect the server and its users**  
+10. **Respect the server and its users**
+    Plain rule: Don't try to disrupt, hack, scrape at scale, or damage goingdark.social or its community.
     [Read more](/docs/policies/rules/10_respect-server/)
-11. **No sharing personal information**  
+11. **No sharing private information**
+    Plain rule: Don't share private information about someone without their consent.
     [Read more](/docs/policies/rules/11_no-doxing/)
 12. **Stop means stop**  
+    Plain rule: If someone asks you to stop engaging with them, stop.  
     [Read more](/docs/policies/rules/12_stop-means-stop/)
 13. **No unapproved bots**  
+    Plain rule: Automated accounts require prior approval.  
     Go directly to the **[Bot Policy](/docs/policies/rules/bots/)**.
-14. **No calls for violence**  
+14. **No calls for violence**
+    Plain rule: Don't promote or encourage harm toward anyone or any group.
     [Read more](/docs/policies/rules/14_no-calls-for-violence/)
 
 ---


### PR DESCRIPTION
## Summary
- add plain-rule summaries to rules index for quick reference
- fix Terms of Service card details in legal section
- clarify operations docs on backups, hosting, and shutdown planning

## Testing
- `pre-commit run --files content/docs/policies/rules/_index.md content/docs/legal/_index.md content/docs/operations/backup-and-restore.md content/docs/operations/hosting-architecture.md content/docs/operations/shutdown-procedure.md`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68a21dc5c058832281cc9ae3c9f4b4d0