### PR TITLE
feat: add status link to footer

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -50,6 +50,7 @@ header:
 
 # Site footer
 footer:
+  text: '[Status](https://status.goingdark.social/)'
   copyright:
     notice: '© {year} goingdark.social'
     license:

--- a/content/docs/operations/incidents.md
+++ b/content/docs/operations/incidents.md
@@ -10,7 +10,7 @@ Administrators watch services and respond to outages.
 
 ### Communication
 
-- Status updates: https://status.goingdark.social/
+- Status updates: https://status.goingdark.social/ (linked in the site footer)
 - Fallback: posts from the administrator account (`@fanfare@goingdark.social`)
 - Send email to contact@goingdark.social
 


### PR DESCRIPTION
## Summary
- link status page from site footer
- mention status link in incidents docs

## Testing
- `pre-commit run --files config/_default/params.yaml content/docs/operations/incidents.md`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a23b6f2b6c8322a8b1a85734e26e4e