### PR TITLE
feat(docs): enable edit links

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -73,6 +73,8 @@ features:
     url: 'https://github.com/goingdark-social/wiki'
     content_dir: 'content'
     branch: 'main'
+  edit_page:
+    enable: true
   feedback:
     responses:
       positive: 'Useful? Start a discussion.'

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -8,6 +8,8 @@ Welcome to the goingdark.social wiki.
 
 This space collects rules, getting started guides, federation policy, moderation notes, and FAQs for the community.
 
+Spot a mistake? Click Edit this page to suggest a change on GitHub.
+
 ## Sections
 
 {{< cards >}}


### PR DESCRIPTION
## Summary
- allow docs pages to display an Edit this page link
- tell readers that docs can be edited on GitHub

## Testing
- `pre-commit run --files config/_default/params.yaml content/docs/_index.md`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a23af1366883228aebb0fbeaae9ac7