### PR TITLE
docs: add moderation handbook skeleton

### DIFF
--- a/content/docs/mods/_index.md
+++ b/content/docs/mods/_index.md
@@ -1,0 +1,18 @@
+---
+title: Moderation Handbook
+weight: 5
+toc: true
+reading_time: false
+pager: true
+---
+
+# Moderation Handbook
+
+This section provides step-by-step guidance for moderators on goingdark.social.
+
+- [Workflow](workflow/) - Standard process from report intake to closure
+- [Evidence](evidence/) - What information to capture and retain
+- [Actions](actions/) - Available enforcement measures
+- [Appeals](appeals/) - How to handle appeals fairly and consistently
+- [Templates](templates/) - Standard communication for moderation outcomes
+- [Playbooks](playbooks/) - Category specific enforcement guides

--- a/content/docs/mods/actions.md
+++ b/content/docs/mods/actions.md
@@ -1,0 +1,19 @@
+---
+title: Actions
+weight: 30
+toc: true
+reading_time: false
+pager: true
+---
+
+# Available Moderator Actions
+
+- **Warn** - private message
+- **Limit** - hide from public timelines on this server. Followers still see posts. Reversible. Formerly called "silence."
+- **Freeze** - local account can view but not post.
+- **Suspend** - temporary or permanent account lock. Data kept up to 30 days. Administrators can force delete earlier.
+- **Delete** - remove harmful content.
+- **Domain block** - block or silence a remote instance.
+- **Reject media** - discard all media from a domain. Posts still arrive.
+
+For each category, see its playbook for the correct action ladder.

--- a/content/docs/mods/appeals.md
+++ b/content/docs/mods/appeals.md
@@ -1,0 +1,18 @@
+---
+title: Appeals Handling
+weight: 40
+toc: true
+reading_time: false
+pager: true
+---
+
+# Appeals Handling
+
+- **Intake**: via the in app appeal page linked from the moderation notice. One appeal per decision.
+- **SLA**:
+  - Acknowledge within 7 days
+  - Decide within 14 days
+- **Window**: users may file an appeal within 20 days of the notice.
+- **Reviewers**: a moderator or administrator decides.
+- **Criteria**: overturn only if clear error or new evidence.
+- **Finality**: decisions after appeal are final unless legally required otherwise.

--- a/content/docs/mods/evidence.md
+++ b/content/docs/mods/evidence.md
@@ -1,0 +1,20 @@
+---
+title: Evidence
+weight: 20
+toc: true
+reading_time: false
+pager: true
+---
+
+# Evidence Guidelines
+
+- **Always capture**:
+  - Account handle and ID
+  - Post URLs or ActivityPub IDs
+  - Timestamps
+- **Screenshots**: take only if content may disappear.
+- **Logs**: note actions taken and reasoning.
+- **Retention**:
+  - Standard: 90 days
+  - Illegal or critical cases: 1 year max, per [privacy](/docs/legal/privacy/)
+- **Access**: restricted to moderators and administrators only.

--- a/content/docs/mods/playbooks/bots-automation.md
+++ b/content/docs/mods/playbooks/bots-automation.md
@@ -1,0 +1,39 @@
+---
+title: Bots / Automated Activity
+weight: 10
+toc: true
+reading_time: false
+pager: true
+---
+
+# Bots / Automated Activity Playbook
+
+## Scope
+Covers unapproved bots, automation, or fake engagement.  
+Linked rule: [Rule 13 - No unapproved bots](/docs/policies/rules/13_bots/).
+
+## Immediate Actions
+- Suspend unapproved bots without notice.  
+- Warn or limit approved bots that misbehave.
+
+## Evidence to Collect
+- Account ID, bot flag setting, example posts.
+
+## Decision Matrix
+- Unapproved bot -> suspend immediately.  
+- Approved but misused -> warn -> limit -> suspend.
+
+## User Notice Template
+"Automated accounts require prior approval. Your bot was suspended for operating outside the policy."
+
+## Federation Actions
+Silence or block noisy remote bots.
+
+## Logging
+Record in moderation log with category = Bots.
+
+## Appeals
+Bot operators may appeal via the in app page with a corrected proposal.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/criminal-activity-extremism.md
+++ b/content/docs/mods/playbooks/criminal-activity-extremism.md
@@ -1,0 +1,39 @@
+---
+title: Criminal Activity / Extremism
+weight: 30
+toc: true
+reading_time: false
+pager: true
+---
+
+# Criminal Activity / Extremism Playbook
+
+## Scope
+Covers promotion of terrorism or criminal activity.  
+Linked rule: [Rule 4 - No illegal content](/docs/policies/rules/04_no-illegal-content/).
+
+## Immediate Actions
+- Remove content and suspend accounts.  
+- Notify administrators; report to authorities if needed.
+
+## Evidence to Collect
+- Account ID, post URLs, any provided materials.
+
+## Decision Matrix
+- Direct promotion -> delete -> suspend -> escalate to administrator.  
+- Historical or news context -> limit if misleading.
+
+## User Notice Template
+"Content promoting crime or extremism isn't allowed. Your account was suspended."
+
+## Federation Actions
+Block or silence servers spreading extremist material.
+
+## Logging
+Record in moderation log with category = Extremism.
+
+## Appeals
+Appeals via the in app page require clear context or error.
+
+## Retention
+Evidence retained for 1 year.

--- a/content/docs/mods/playbooks/csam.md
+++ b/content/docs/mods/playbooks/csam.md
@@ -1,0 +1,38 @@
+---
+title: Child Sexual Exploitation Material
+weight: 20
+toc: true
+reading_time: false
+pager: true
+---
+
+# Child Sexual Exploitation Material Playbook
+
+## Scope
+Covers images or posts exploiting minors.  
+Linked rule: [Rule 4 - No illegal content](/docs/policies/rules/04_no-illegal-content/).
+
+## Immediate Actions
+- Suspend account and remove content.  
+- Report to administrators and law enforcement when required.
+
+## Evidence to Collect
+- Account ID, post URLs, hashes if known.
+
+## Decision Matrix
+- Any child sexual abuse material -> delete -> suspend -> escalate to administrator.
+
+## User Notice Template
+"Content involving minors is illegal. Your account was suspended and reported."
+
+## Federation Actions
+Block or silence remote instances sharing child sexual abuse material.
+
+## Logging
+Record in moderation log with category = child sexual abuse material.
+
+## Appeals
+No appeals allowed for child sexual abuse material.
+
+## Retention
+Evidence retained for 1 year.

--- a/content/docs/mods/playbooks/defamation.md
+++ b/content/docs/mods/playbooks/defamation.md
@@ -1,0 +1,38 @@
+---
+title: Defamation
+weight: 40
+toc: true
+reading_time: false
+pager: true
+---
+
+# Defamation Playbook
+
+## Scope
+Covers false statements harming someone's reputation.  
+Linked rule: [Rule 1 - Treat people well](/docs/policies/rules/01_treat-people-well/).
+
+## Immediate Actions
+- Remove defamatory content.  
+- Warn or suspend depending on severity.
+
+## Evidence to Collect
+- Account ID, post URLs, context from reporter.
+
+## Decision Matrix
+- Clear defamation -> delete -> warn -> suspend for repeats.
+
+## User Notice Template
+"False statements about others violate our rules. Your post was removed."
+
+## Federation Actions
+Limit or block instances that host persistent defamation.
+
+## Logging
+Record in moderation log with category = Defamation.
+
+## Appeals
+Users may appeal via the in app page with supporting evidence.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/harassment-bullying.md
+++ b/content/docs/mods/playbooks/harassment-bullying.md
@@ -1,0 +1,39 @@
+---
+title: Harassment / Bullying
+weight: 60
+toc: true
+reading_time: false
+pager: true
+---
+
+# Harassment / Bullying Playbook
+
+## Scope
+Covers targeted harassment or bullying of individuals.  
+Linked rule: [Rule 1 - Treat people well](/docs/policies/rules/01_treat-people-well/).
+
+## Immediate Actions
+- Warn first time offenders.
+- Silence or suspend for repeated behavior.
+
+## Evidence to Collect
+- Account ID, post URLs, reports from victims.
+
+## Decision Matrix
+- Single incident -> warn.  
+- Repeated or severe -> limit -> suspend.
+
+## User Notice Template
+"Harassing other users isn't allowed. Your account may be restricted."
+
+## Federation Actions
+Silence or block instances fostering harassment.
+
+## Logging
+Record in moderation log with category = Harassment.
+
+## Appeals
+Victims or offenders may appeal via the in app page with context.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/hate-speech.md
+++ b/content/docs/mods/playbooks/hate-speech.md
@@ -1,0 +1,39 @@
+---
+title: Hate Speech
+weight: 70
+toc: true
+reading_time: false
+pager: true
+---
+
+# Hate Speech Playbook
+
+## Scope
+Covers attacks on protected groups.  
+Linked rule: [Rule 6 - No hate or threats](/docs/policies/rules/06_no-hate-or-threats/).
+
+## Immediate Actions
+- Delete content.  
+- Suspend for severe cases.
+
+## Evidence to Collect
+- Account ID, post URLs, group targeted.
+
+## Decision Matrix
+- Slurs -> delete -> warn -> suspend for repeats.  
+- Calls for violence -> delete and suspend.
+
+## User Notice Template
+"Hate toward protected groups violates our rules. Your post was removed."
+
+## Federation Actions
+Block or silence instances hosting hate speech.
+
+## Logging
+Record in moderation log with category = Hate Speech.
+
+## Appeals
+Appeals allowed via the in app page if context was misunderstood.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/human-exploitation.md
+++ b/content/docs/mods/playbooks/human-exploitation.md
@@ -1,0 +1,38 @@
+---
+title: Human Exploitation
+weight: 80
+toc: true
+reading_time: false
+pager: true
+---
+
+# Human Exploitation Playbook
+
+## Scope
+Covers trafficking, forced labor, or similar abuse.  
+Linked rule: [Rule 4 - No illegal content](/docs/policies/rules/04_no-illegal-content/).
+
+## Immediate Actions
+- Remove content and suspend accounts.  
+- Report to administrators and law enforcement as required.
+
+## Evidence to Collect
+- Account ID, post URLs, any recruitment details.
+
+## Decision Matrix
+- Evidence of exploitation -> delete -> suspend -> escalate.
+
+## User Notice Template
+"Human exploitation is illegal. Your account was suspended and reported."
+
+## Federation Actions
+Block or silence servers promoting exploitation.
+
+## Logging
+Record in moderation log with category = Human Exploitation.
+
+## Appeals
+No appeals unless error was made. Use the in app appeal page to explain.
+
+## Retention
+Evidence retained for 1 year.

--- a/content/docs/mods/playbooks/impersonation.md
+++ b/content/docs/mods/playbooks/impersonation.md
@@ -1,0 +1,39 @@
+---
+title: Impersonation
+weight: 100
+toc: true
+reading_time: false
+pager: true
+---
+
+# Impersonation Playbook
+
+## Scope
+Covers accounts pretending to be someone else.  
+Linked rule: [Rule 9 - Honest identity](/docs/policies/rules/09_honest-identity/).
+
+## Immediate Actions
+- Warn or suspend depending on intent.  
+- Require clear labeling for parody accounts.
+
+## Evidence to Collect
+- Account ID, profile screenshots, complaints.
+
+## Decision Matrix
+- Parody with label -> allow.  
+- Deceptive impersonation -> suspend.
+
+## User Notice Template
+"Impersonation without clear parody labels isn't allowed. Your account was suspended."
+
+## Federation Actions
+Silence or block servers that host impersonation networks.
+
+## Logging
+Record in moderation log with category = Impersonation.
+
+## Appeals
+Appeals via the in app page require proof of authorization.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/inauthentic-behavior.md
+++ b/content/docs/mods/playbooks/inauthentic-behavior.md
@@ -1,0 +1,39 @@
+---
+title: Inauthentic Behavior
+weight: 90
+toc: true
+reading_time: false
+pager: true
+---
+
+# Inauthentic Behavior Playbook
+
+## Scope
+Covers coordinated or deceptive actions to mislead users.  
+Linked rule: [Rule 9 - Honest identity](/docs/policies/rules/09_honest-identity/).
+
+## Immediate Actions
+- Limit reach of suspected networks.  
+- Suspend accounts for clear manipulation.
+
+## Evidence to Collect
+- Account IDs, related domains, coordination signals.
+
+## Decision Matrix
+- Minor coordination -> warn -> limit.  
+- Clear deception -> suspend.
+
+## User Notice Template
+"Coordinated manipulation isn't allowed. Your account was restricted."
+
+## Federation Actions
+Silence or block networks engaging in manipulation.
+
+## Logging
+Record in moderation log with category = Inauthentic Behavior.
+
+## Appeals
+Operators may appeal via the in app page with proof of authenticity.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/intellectual-property.md
+++ b/content/docs/mods/playbooks/intellectual-property.md
@@ -1,0 +1,38 @@
+---
+title: Intellectual Property
+weight: 110
+toc: true
+reading_time: false
+pager: true
+---
+
+# Intellectual Property Playbook
+
+## Scope
+Covers copyright or trademark violations.  
+Linked rule: [Rule 4 - No illegal content](/docs/policies/rules/04_no-illegal-content/).
+
+## Immediate Actions
+- Remove infringing content.  
+- Suspend repeat offenders.
+
+## Evidence to Collect
+- Account ID, URLs, removal notices.
+
+## Decision Matrix
+- Valid complaint -> delete -> warn -> suspend for repeats.
+
+## User Notice Template
+"Your post was removed for violating intellectual property rights."
+
+## Federation Actions
+Share notices with affected servers and block persistent offenders.
+
+## Logging
+Record in moderation log with category = Intellectual Property.
+
+## Appeals
+Users may appeal via the in app page with proof of rights.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/misinformation.md
+++ b/content/docs/mods/playbooks/misinformation.md
@@ -1,0 +1,38 @@
+---
+title: Misinformation
+weight: 50
+toc: true
+reading_time: false
+pager: true
+---
+
+# Misinformation Playbook
+
+## Scope
+Covers false or misleading information that could cause harm.  
+Linked rule: [Rule 1 - Treat people well](/docs/policies/rules/01_treat-people-well/).
+
+## Immediate Actions
+- Label or remove harmful misinformation.  
+- Limit reach for repeat offenders.
+
+## Evidence to Collect
+- Account ID, post URLs, source references.
+
+## Decision Matrix
+- Harmful misinformation -> label -> delete -> suspend for repeats.
+
+## User Notice Template
+"Spreading false information that harms others isn't allowed. Your post was removed."
+
+## Federation Actions
+Silence or block sources of coordinated misinformation.
+
+## Logging
+Record in moderation log with category = Misinformation.
+
+## Appeals
+Users may appeal via the in app page with credible sources.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/ncii.md
+++ b/content/docs/mods/playbooks/ncii.md
@@ -1,0 +1,38 @@
+---
+title: Non consensual Intimate Imagery
+weight: 120
+toc: true
+reading_time: false
+pager: true
+---
+
+# Non consensual Intimate Imagery Playbook
+
+## Scope
+Covers sharing intimate images without consent.  
+Linked rule: [Rule 4 - No illegal content](/docs/policies/rules/04_no-illegal-content/).
+
+## Immediate Actions
+- Remove content and suspend account.  
+- Notify administrators and law enforcement as required.
+
+## Evidence to Collect
+- Account ID, post URLs, hashes if available.
+
+## Decision Matrix
+- Any non consensual intimate imagery -> delete -> suspend -> escalate.
+
+## User Notice Template
+"Sharing intimate images without consent is illegal. Your account was suspended."
+
+## Federation Actions
+Block or silence instances sharing such material.
+
+## Logging
+Record in moderation log with category = non consensual intimate imagery.
+
+## Appeals
+No appeals unless mistaken identity. Use the in app appeal page to explain.
+
+## Retention
+Evidence retained for 1 year.

--- a/content/docs/mods/playbooks/phishing-malware.md
+++ b/content/docs/mods/playbooks/phishing-malware.md
@@ -1,0 +1,38 @@
+---
+title: Phishing / Malware
+weight: 130
+toc: true
+reading_time: false
+pager: true
+---
+
+# Phishing / Malware Playbook
+
+## Scope
+Covers attempts to steal credentials or deliver malicious software.  
+Linked rule: [Rule 5 - No spam](/docs/policies/rules/05_no-spam/).
+
+## Immediate Actions
+- Remove posts and suspend accounts.  
+- Report malicious links to hosting providers.
+
+## Evidence to Collect
+- Account ID, URLs, payload samples.
+
+## Decision Matrix
+- Confirmed phishing or malware -> delete -> suspend -> escalate.
+
+## User Notice Template
+"Phishing and malware are prohibited. Your account was suspended."
+
+## Federation Actions
+Block or silence domains distributing malware.
+
+## Logging
+Record in moderation log with category = Phishing.
+
+## Appeals
+Appeals via the in app page require proof of false positive.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/regulated-goods-services.md
+++ b/content/docs/mods/playbooks/regulated-goods-services.md
@@ -1,0 +1,39 @@
+---
+title: Regulated Goods / Services
+weight: 150
+toc: true
+reading_time: false
+pager: true
+---
+
+# Regulated Goods / Services Playbook
+
+## Scope
+Covers trade of regulated items like drugs, weapons, or financial services.  
+Linked rule: [Rule 4 - No illegal content](/docs/policies/rules/04_no-illegal-content/).
+
+## Immediate Actions
+- Remove listings.  
+- Suspend or limit accounts for repeated sales.
+
+## Evidence to Collect
+- Account ID, post URLs, item details.
+
+## Decision Matrix
+- Illegal sale -> delete -> suspend -> escalate.  
+- Legal but restricted -> warn -> limit.
+
+## User Notice Template
+"Selling regulated goods isn't allowed. Your post was removed."
+
+## Federation Actions
+Block or silence instances trading in restricted goods.
+
+## Logging
+Record in moderation log with category = Regulated Goods.
+
+## Appeals
+Appeals via the in app page must show the item is legal and allowed.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/sexual-content.md
+++ b/content/docs/mods/playbooks/sexual-content.md
@@ -1,0 +1,39 @@
+---
+title: Sexual Content
+weight: 140
+toc: true
+reading_time: false
+pager: true
+---
+
+# Sexual Content Playbook
+
+## Scope
+Covers explicit sexual material not allowed by site rules.  
+Linked rule: [Rule 3 - Keep it clean](/docs/policies/rules/03_keep-it-clean/).
+
+## Immediate Actions
+- Remove explicit content.  
+- Warn or suspend for repeated posts.
+
+## Evidence to Collect
+- Account ID, post URLs, screenshots if needed.
+
+## Decision Matrix
+- Mild nudity -> warn -> limit.  
+- Explicit sex acts -> delete -> suspend.
+
+## User Notice Template
+"Explicit sexual content isn't allowed here. Your post was removed."
+
+## Federation Actions
+Silence or block instances that host explicit content.
+
+## Logging
+Record in moderation log with category = Sexual Content.
+
+## Appeals
+Appeals via the in app page considered for context or tagging errors.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/spam.md
+++ b/content/docs/mods/playbooks/spam.md
@@ -1,0 +1,39 @@
+---
+title: Spam
+weight: 160
+toc: true
+reading_time: false
+pager: true
+---
+
+# Spam Playbook
+
+## Scope
+Covers unsolicited bulk messages or repetitive content.  
+Linked rule: [Rule 5 - No spam](/docs/policies/rules/05_no-spam/).
+
+## Immediate Actions
+- Delete spam posts.  
+- Suspend accounts for persistent spam.
+
+## Evidence to Collect
+- Account ID, post URLs, sample messages.
+
+## Decision Matrix
+- First offense -> warn -> limit.  
+- Persistent spam -> suspend.
+
+## User Notice Template
+"Spam isn't allowed. Your account was limited."
+
+## Federation Actions
+Silence or block servers that send spam often.
+
+## Logging
+Record in moderation log with category = Spam.
+
+## Appeals
+Appeals via the in app page require proof messages were solicited.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/suicide-selfharm.md
+++ b/content/docs/mods/playbooks/suicide-selfharm.md
@@ -1,0 +1,39 @@
+---
+title: Suicide / Self harm
+weight: 170
+toc: true
+reading_time: false
+pager: true
+---
+
+# Suicide / Self harm Playbook
+
+## Scope
+Covers content encouraging self harm or suicide.  
+Linked rule: [Rule 1 - Treat people well](/docs/policies/rules/01_treat-people-well/).
+
+## Immediate Actions
+- Reach out with resources if possible.  
+- Remove content and suspend if actively encouraging harm.
+
+## Evidence to Collect
+- Account ID, post URLs, context about intent.
+
+## Decision Matrix
+- Cry for help -> refer to support -> limit.  
+- Encouraging self harm -> delete -> suspend.
+
+## User Notice Template
+"Posts encouraging self harm aren't allowed. The content was removed and help resources were provided."
+
+## Federation Actions
+Silence or block servers that promote self harm.
+
+## Logging
+Record in moderation log with category = Self harm.
+
+## Appeals
+Appeals via the in app page considered if content was support seeking.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/playbooks/violence-gore.md
+++ b/content/docs/mods/playbooks/violence-gore.md
@@ -1,0 +1,39 @@
+---
+title: Violence / Gore
+weight: 180
+toc: true
+reading_time: false
+pager: true
+---
+
+# Violence / Gore Playbook
+
+## Scope
+Covers graphic violence or gore.  
+Linked rule: [Rule 3 - Keep it clean](/docs/policies/rules/03_keep-it-clean/).
+
+## Immediate Actions
+- Remove graphic content.  
+- Warn or suspend for repeated posts.
+
+## Evidence to Collect
+- Account ID, post URLs, screenshots if needed.
+
+## Decision Matrix
+- Mild violence -> warn -> limit.  
+- Graphic gore -> delete -> suspend.
+
+## User Notice Template
+"Graphic violence or gore isn't allowed. Your post was removed."
+
+## Federation Actions
+Block or silence instances hosting violent media.
+
+## Logging
+Record in moderation log with category = Violence.
+
+## Appeals
+Appeals via the in app page considered for news or educational context.
+
+## Retention
+Evidence retained for 90 days.

--- a/content/docs/mods/templates.md
+++ b/content/docs/mods/templates.md
@@ -1,0 +1,28 @@
+---
+title: Templates
+weight: 50
+toc: true
+reading_time: false
+pager: true
+---
+
+# User Notice Templates
+
+### Warning
+"Your recent activity violates our rules: [category]. Please adjust. Repeated issues may lead to stronger action."
+
+### Content Removal
+"Your post was removed for violating our rules on [category]. Future violations may lead to suspension."
+
+### Suspension
+"Your account has been suspended for violating our rules on [category]. You may appeal within 20 days via the in app appeal page linked in the notice."
+
+### Domain Block
+"This domain has been blocked due to repeated violations of our policies. See transparency log for details."
+
+### Statement of Reasons
+Required by EU law. Include:
+- Content affected
+- Decision taken
+- Rule or law violated
+- Appeal options

--- a/content/docs/mods/workflow.md
+++ b/content/docs/mods/workflow.md
@@ -1,0 +1,32 @@
+---
+title: Moderation Workflow
+weight: 10
+toc: true
+reading_time: false
+pager: true
+---
+
+# Standard Workflow
+
+1. **Intake**
+   - Receive report via in app tool.
+   - Check if the issue falls under a playbook category.
+
+2. **Evidence capture**  
+   - Record account ID, post ID, screenshot if ephemeral.  
+   - Store securely according to [Evidence](evidence/).  
+
+3. **Apply playbook**  
+   - Follow the decision matrix for the relevant category.  
+
+4. **Action**  
+   - Choose proportionate action (see [Actions](actions/)).  
+
+5. **Notification**  
+   - Send appropriate template from [Templates](templates/).  
+
+6. **Logging**  
+   - Record action for transparency and metrics.  
+
+7. **Closure**  
+   - Mark case resolved. Forward to administrator or legal if required.


### PR DESCRIPTION
## Summary
- add moderator handbook index and core workflow docs
- scaffold 18 category playbooks for moderators
- update appeals, actions, and templates for Mastodon specifics

## Testing
- `pre-commit run --files content/docs/mods/actions.md content/docs/mods/appeals.md content/docs/mods/playbooks/bots-automation.md content/docs/mods/playbooks/criminal-activity-extremism.md content/docs/mods/playbooks/defamation.md content/docs/mods/playbooks/harassment-bullying.md content/docs/mods/playbooks/hate-speech.md content/docs/mods/playbooks/human-exploitation.md content/docs/mods/playbooks/impersonation.md content/docs/mods/playbooks/inauthentic-behavior.md content/docs/mods/playbooks/intellectual-property.md content/docs/mods/playbooks/misinformation.md content/docs/mods/playbooks/ncii.md content/docs/mods/playbooks/phishing-malware.md content/docs/mods/playbooks/regulated-goods-services.md content/docs/mods/playbooks/sexual-content.md content/docs/mods/playbooks/spam.md content/docs/mods/playbooks/suicide-selfharm.md content/docs/mods/playbooks/violence-gore.md content/docs/mods/templates.md content/docs/mods/workflow.md`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a2510b48188322aa956824f5c4eb36