### PR TITLE
docs: add help page and menu link

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -46,3 +46,7 @@ sidebar:
     params:
       type: separator
     weight: 90
+  - identifier: help
+    name: Help
+    pageRef: "/docs/user/help"
+    weight: 91

--- a/content/docs/user/_index.md
+++ b/content/docs/user/_index.md
@@ -3,15 +3,15 @@ title: User guides
 weight: 20
 ---
 {{< cards >}}
+  {{< card url="help/" title="Help" icon="lifebuoy" subtitle="How to get support" >}}
   {{< card url="migration/" title="Migration" icon="arrow-right-on-rectangle" subtitle="How to move your account between servers" >}}
   {{< card url="reporting/" title="Reporting" icon="flag" subtitle="How to report problems to moderators" >}}
   {{< card url="getting-started/" title="Getting Started" icon="sparkles" subtitle="Step-by-step onboarding for new users" >}}
   {{< card url="faq/" title="FAQ" icon="question-mark-circle" subtitle="Frequently asked questions" >}}
 {{< /cards >}}
 
-## See Also
+## See also
 
-- [Community Guidelines](/docs/community/) - Learn about our community culture
+- [Community Guidelines](/docs/community/) - Learn about the community culture
 - [Rules](../policies/rules/) - Review the official server rules
 - [Legal](../legal/) - Terms of service and privacy policy
-

--- a/content/docs/user/help.md
+++ b/content/docs/user/help.md
@@ -1,0 +1,19 @@
+---
+title: Help
+weight: 40
+toc: true
+reading_time: false
+pager: true
+---
+
+Need a hand? Reach the team through the channels below.
+
+## Contact
+
+- **Email:** `support@goingdark.social` - replies in 48 hours.
+- **GitHub discussions:** <https://github.com/goingdark-social/wiki/discussions> - community replies in about a week.
+
+## More resources
+
+- [Reporting issues](reporting/)
+- [FAQ](faq/)


### PR DESCRIPTION
## Summary
- add user help page with contact options and resources
- expose help page in docs sidebar and user guide index

## Testing
- `pre-commit run --files config/_default/menus.yaml content/docs/user/_index.md content/docs/user/help.md`
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68a2410130b0832294179c0a506b12f2