### PR TITLE
docs: add service status page

### DIFF
--- a/content/docs/user/status.md
+++ b/content/docs/user/status.md
@@ -1,0 +1,25 @@
+---
+title: "Service Status"
+weight: 40
+toc: true
+reading_time: false
+pager: true
+---
+
+Check the status page for live updates on outages.
+
+https://status.goingdark.social/
+
+### Current incidents
+
+- None reported. Known issues and fixes appear here.
+
+### Workarounds
+
+- Try the web app if your mobile app fails.
+- If sign in doesn't work, email `contact@goingdark.social`.
+
+### Maintenance windows
+
+Routine maintenance starts on the first Tuesday of each month at 02:00 UTC.
+Updates appear on the status page and from `@fanfare@goingdark.social`.


### PR DESCRIPTION
## Summary
- add user status page with incident info and maintenance schedule

## Testing
- `pre-commit run --files content/docs/user/status.md`
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68a240f9e924832284891ae0dbf015f2