### PR TITLE
docs: switch contact to mastodon

### DIFF
--- a/content/docs/community/community-guidelines.md
+++ b/content/docs/community/community-guidelines.md
@@ -92,10 +92,10 @@ Harassment or abusive activity that happens off-platform but impacts our members
 
 ## Reporting
 
-- Use the **Report** button on any post or profile.  
-- Reports go directly to the admin/moderator team.  
-- Email [abuse@goingdark.social](mailto:abuse@goingdark.social) for urgent or complex issues.  
-- Reports are reviewed promptly. Outcomes may be communicated if appropriate.  
+- Use the **Report** button on any post or profile.
+- Reports go directly to the admin/moderator team.
+- For urgent or complex issues, send a direct message on Mastodon to `@fanfare@goingdark.social`.
+- Reports are reviewed promptly. Outcomes may be communicated if appropriate.
 
 ---
 

--- a/content/docs/legal/appeals.md
+++ b/content/docs/legal/appeals.md
@@ -10,7 +10,7 @@ If your content or account has been restricted, you can ask for a review.
 
 ## How to appeal
 
-- Email **support@goingdark.social** from the address on your account.
+- Send a direct message on Mastodon to `@fanfare@goingdark.social` from the account in question.
 - Include links to the affected posts or your profile, and any context you believe is relevant.
 
 ## What happens next

--- a/content/docs/legal/privacy.md
+++ b/content/docs/legal/privacy.md
@@ -23,7 +23,7 @@ Only administrators can access logs.
 This privacy policy explains how **goingdark.social** ("Going Dark", "we", "us") processes personal data when you use our Mastodon service. We are an EU-based, privacy-first community. We do not use analytics, advertising, or unnecessary cookies. Access to the service is restricted to adults aged 18 and over.
 
 **Controller**: Administrators of goingdark.social
-**Privacy contact**: [admin@goingdark.social](mailto:admin@goingdark.social)
+**Privacy contact**: message `@fanfare@goingdark.social` on Mastodon
 **Supervisory authority**: You can lodge a complaint with your local authority. In Sweden this is Integritetsskyddsmyndigheten (IMY) at [https://www.imy.se](https://www.imy.se).
 
 ---
@@ -54,8 +54,6 @@ We process only what is necessary to run a Mastodon server. Each purpose has a l
   **Legal basis**: contract necessity, Article 6(1)(b) GDPR.
 * **Community safety, moderation, and network security**: prevent spam and ban evasion, investigate abuse reports, protect accounts, maintain service integrity. This includes limited IP logging and review of server logs when needed.
   **Legal basis**: legitimate interests, Article 6(1)(f) GDPR, supported by Recital 49 on network and information security. You may object to this processing as described in **Your rights**.
-* **Optional communications**: non-essential announcements by email if you opt in.
-  **Legal basis**: consent, Article 6(1)(a) GDPR. You can withdraw consent at any time.
 
 # How do we protect your information?
 
@@ -101,7 +99,7 @@ Mastodon is federated. When you post or interact with accounts on other servers,
 
 Subject to conditions in the GDPR, you have the right to access, rectification, erasure, restriction, data portability, and to object to processing based on legitimate interests. You can withdraw consent at any time for processing that relies on consent. You also have the right to lodge a complaint with a supervisory authority. In Sweden this is IMY at [https://www.imy.se](https://www.imy.se).
 
-To exercise your rights, contact [admin@goingdark.social](mailto:admin@goingdark.social). We will respond within one month or explain if an extension is needed for complex requests.
+To exercise your rights, message `@fanfare@goingdark.social` on Mastodon. We will respond within one month or explain if an extension is needed for complex requests.
 
 # Site usage by children
 

--- a/content/docs/legal/terms-of-service.md
+++ b/content/docs/legal/terms-of-service.md
@@ -55,7 +55,7 @@ We enforce our rules using a mix of automated anti-spam and abuse filters, block
 
 ## Notice and action for illegal content or rights complaints
 
-* **User and authority contact**: [support@goingdark.social](mailto:support@goingdark.social)
+* **User and authority contact**: message `@fanfare@goingdark.social` on Mastodon
 * **Web form**: use the notice form linked on our legal page to submit reports. Include the URL or ActivityPub ID, a description, your legal basis or proof of rights, and your contact details.
 * We review notices diligently and may restrict content or accounts where appropriate. When we restrict content or an account, we provide a **Statement of Reasons** identifying the decision, the basis, and the available redress routes.
 * We comply with valid orders to act against illegal content or provide information where required by law.
@@ -95,7 +95,7 @@ We do not exclude or limit liability where the law does not allow it. In particu
 
 ## Governing law and venue; informal resolution
 
-These Terms are governed by the laws of **Sweden** and applicable EU law. Before bringing a claim, both sides will try to resolve the matter informally by email within 30 days. If unresolved, disputes may be brought before the competent Swedish courts, except that mandatory consumer rights to bring proceedings in your local competent court are preserved.
+These Terms are governed by the laws of **Sweden** and applicable EU law. Before bringing a claim, both sides will try to resolve the matter informally via Mastodon direct message or the wiki discussions tab within 30 days. If unresolved, disputes may be brought before the competent Swedish courts, except that mandatory consumer rights to bring proceedings in your local competent court are preserved.
 
 ## Changes to these Terms
 
@@ -103,4 +103,4 @@ We may update these Terms. Material changes will be announced on the site. Conti
 
 ## Contact
 
-User and legal contact: **[support@goingdark.social](mailto:support@goingdark.social)**. We accept notices in English or Swedish.
+User and legal contact: message `@fanfare@goingdark.social` on Mastodon. We accept notices in English or Swedish.

--- a/content/docs/mods/appeals.md
+++ b/content/docs/mods/appeals.md
@@ -8,7 +8,7 @@ pager: true
 
 # Appeals Handling
 
-- **Intake**: via `support@goingdark.social` or form.
+- **Intake**: via Mastodon message to `@fanfare@goingdark.social` or form.
 - **SLA**:
   - Acknowledge within 7 days
   - Decide within 14 days

--- a/content/docs/mods/workflow.md
+++ b/content/docs/mods/workflow.md
@@ -8,9 +8,9 @@ pager: true
 
 # Standard Workflow
 
-1. **Intake**  
-   - Receive report via in app tool or email.  
-   - Check if the issue falls under a playbook category.  
+1. **Intake**
+   - Receive report via in app tool or Mastodon message.
+   - Check if the issue falls under a playbook category.
 
 2. **Evidence capture**  
    - Record account ID, post ID, screenshot if ephemeral.  

--- a/content/docs/operations/incidents.md
+++ b/content/docs/operations/incidents.md
@@ -12,7 +12,7 @@ Administrators watch services and respond to outages.
 
 - Status updates: https://status.goingdark.social/ (linked in the site footer)
 - Fallback: posts from the administrator account (`@fanfare@goingdark.social`)
-- Send email to contact@goingdark.social
+- For urgent help, send a direct message to `@fanfare@goingdark.social` on Mastodon.
 
 ### Postmortem template
 

--- a/content/docs/operations/shutdown-procedure.md
+++ b/content/docs/operations/shutdown-procedure.md
@@ -22,7 +22,6 @@ If the service ever shuts down:
 
 - Export data.
 - Migrate account.
-- Set email forwarding.
 
 ### Technical plan
 

--- a/content/docs/overview/about.md
+++ b/content/docs/overview/about.md
@@ -13,8 +13,8 @@ The service is run by Going Dark, a small community based in the EU.
 
 Right now the server runs at home and personal funds cover the costs. Learn how to help at [Support Us](/docs/user/support-us/)
 
-Contact: contact@goingdark.social
-Abuse reports: abuse@goingdark.social  
+Contact: `@fanfare@goingdark.social` on Mastodon
+Abuse reports: direct message `@fanfare@goingdark.social`
 Support requests receive answers in 72 hours.
 
 See also:

--- a/content/docs/policies/moderation-guidelines.md
+++ b/content/docs/policies/moderation-guidelines.md
@@ -17,7 +17,7 @@ These guidelines cover moderation on goingdark.social. They apply to local accou
 - **Domain block**: remote server hidden.
 - **Account deletion**: data removed after self destruct.
 
-Email notifications are sent for each action.
+In-app notifications are sent for each action.
 
 ### Behavior mapping
 

--- a/content/docs/policies/moderation-report.md
+++ b/content/docs/policies/moderation-report.md
@@ -10,4 +10,4 @@ We publish a periodic summary of moderation activity (reports, actions, and fede
 
 The figures are included in our [Transparency Metrics](/docs/transparency/metrics/). This page exists to avoid broken links from older documents and to provide a stable reference.
 
-If you need more detail, contact **support@goingdark.social**.
+If you need more detail, send a direct message on Mastodon to `@fanfare@goingdark.social`.

--- a/content/docs/policies/rules/01_treat-people-well.md
+++ b/content/docs/policies/rules/01_treat-people-well.md
@@ -18,4 +18,4 @@ pager: true
 - Insult, belittle, or bait people.
 - Dogpile or brigade.
 
-**Enforcement:** Breaches may lead to a warning, limit, or suspension per the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Report issues via the in-app report or at [abuse@goingdark.social](mailto:abuse@goingdark.social). See [Reporting](/docs/user/reporting/).
+**Enforcement:** Breaches may lead to a warning, limit, or suspension per the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Report issues via the in-app report or by messaging `@fanfare@goingdark.social` on Mastodon. See [Reporting](/docs/user/reporting/).

--- a/content/docs/policies/rules/02_content-warnings.md
+++ b/content/docs/policies/rules/02_content-warnings.md
@@ -16,4 +16,4 @@ pager: true
 
 **Do not:** use CWs to hide abuse or evade moderation.
 
-**Enforcement:** Posts may be limited or removed. Repeated issues can lead to account actions per the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Report concerns via the report tool or [abuse@goingdark.social](mailto:abuse@goingdark.social).
+**Enforcement:** Posts may be limited or removed. Repeated issues can lead to account actions per the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Report concerns via the report tool or by messaging `@fanfare@goingdark.social` on Mastodon.

--- a/content/docs/policies/rules/08_consequences.md
+++ b/content/docs/policies/rules/08_consequences.md
@@ -8,4 +8,4 @@ pager: true
 
 **Plain rule:** Violations can lead to a warning, limit, silencing, or permanent suspension. Severe cases may skip steps.
 
-**Appeals:** You can appeal as described in the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Use in-app reports or email [abuse@goingdark.social](mailto:abuse@goingdark.social).
+**Appeals:** You can appeal as described in the [Moderation Guidelines](/docs/policies/moderation-guidelines/). Use in-app reports or message `@fanfare@goingdark.social` on Mastodon.

--- a/content/docs/user/help.md
+++ b/content/docs/user/help.md
@@ -10,8 +10,8 @@ Need a hand? Reach the team through the channels below.
 
 ## Contact
 
-- **Email:** `support@goingdark.social` - replies in 48 hours.
-- **GitHub discussions:** <https://github.com/goingdark-social/wiki/discussions> - community replies in about a week.
+- **Mastodon:** `@fanfare@goingdark.social` - send a direct message for support or reports.
+- **Wiki discussions:** <https://github.com/goingdark-social/wiki/discussions> - feedback and questions.
 
 ## More resources
 

--- a/content/docs/user/reporting.md
+++ b/content/docs/user/reporting.md
@@ -26,5 +26,5 @@ Most apps include a **Report** option in the post menu. Include as much context 
 
 Moderators review reports in 48 hours and can contact you for details. You receive a notification when the case closes.
 
-Abuse inbox: abuse@goingdark.social.
+For urgent issues, send a direct message on Mastodon to `@fanfare@goingdark.social`.
 

--- a/content/docs/user/status.md
+++ b/content/docs/user/status.md
@@ -17,7 +17,7 @@ https://status.goingdark.social/
 ### Workarounds
 
 - Try the web app if your mobile app fails.
-- If sign in doesn't work, email `contact@goingdark.social`.
+- If sign in doesn't work, post in the wiki discussions tab.
 
 ### Maintenance windows
 

--- a/content/docs/user/support-us.md
+++ b/content/docs/user/support-us.md
@@ -11,7 +11,7 @@ Our small server runs on home hardware and personal funds cover the bills. If yo
 ## Donation Options
 
 - [Ko-fi](https://ko-fi.com/goingdark) - one-off or recurring tips.
-- Direct bank transfer - ask at contact@goingdark.social for details.
+- Direct bank transfer - ask via Mastodon at `@fanfare@goingdark.social` for details.
 
 ## How We Use Funds
 


### PR DESCRIPTION
## Summary
- replace email-based contact with mastodon handle @fanfare@goingdark.social
- direct questions and support to the wiki discussions tab
- update legal and policy docs to match new contact methods

## Testing
- `pre-commit run --files content/docs/community/community-guidelines.md content/docs/legal/appeals.md content/docs/legal/privacy.md content/docs/legal/terms-of-service.md content/docs/mods/appeals.md content/docs/mods/workflow.md content/docs/operations/incidents.md content/docs/operations/shutdown-procedure.md content/docs/overview/about.md content/docs/policies/moderation-guidelines.md content/docs/policies/moderation-report.md content/docs/policies/rules/01_treat-people-well.md content/docs/policies/rules/02_content-warnings.md content/docs/policies/rules/08_consequences.md content/docs/user/help.md content/docs/user/reporting.md content/docs/user/status.md content/docs/user/support-us.md`
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68a2f66062f08322a4d7c19a3f464e1e