### PR TITLE
docs: standardize appeal instructions

### DIFF
--- a/.vale/Project/spelling-exceptions.txt
+++ b/.vale/Project/spelling-exceptions.txt
@@ -82,3 +82,6 @@ UTC
 tootctl
 signup
 signups
+in-app
+In-app
+non-discriminatory

--- a/content/docs/community/community-guidelines.md
+++ b/content/docs/community/community-guidelines.md
@@ -94,7 +94,7 @@ Harassment or abusive activity that happens off-platform but impacts our members
 
 - Use the **Report** button on any post or profile.
 - Reports go directly to the admin/moderator team.
-- For urgent or complex issues, send a direct message on Mastodon to `@fanfare@goingdark.social`.
+- For urgent or complex issues, use the in-app Appeal button on the warning page. If the site is unavailable, send a DM to `@fanfare@goingdark.social`.
 - Reports are reviewed promptly. Outcomes may be communicated if appropriate.
 
 ---

--- a/content/docs/legal/appeals.md
+++ b/content/docs/legal/appeals.md
@@ -10,7 +10,7 @@ If your content or account has been restricted, you can ask for a review.
 
 ## How to appeal
 
-- Send a direct message on Mastodon to `@fanfare@goingdark.social` from the account in question.
+- Use the in-app Appeal button on the warning page. If the site is unavailable, send a DM to `@fanfare@goingdark.social`.
 - Include links to the affected posts or your profile, and any context you believe is relevant.
 
 ## What happens next

--- a/content/docs/mods/appeals.md
+++ b/content/docs/mods/appeals.md
@@ -8,7 +8,7 @@ pager: true
 
 # Appeals Handling
 
-- **Intake**: via Mastodon message to `@fanfare@goingdark.social` or form.
+- **Intake**: Use the in-app Appeal button on the warning page. If the site is unavailable, send a DM to `@fanfare@goingdark.social`.
 - **SLA**:
   - Acknowledge within 7 days
   - Decide within 14 days

--- a/content/docs/policies/moderation-guidelines.md
+++ b/content/docs/policies/moderation-guidelines.md
@@ -29,5 +29,8 @@ In-app notifications are sent for each action.
 
 ### Appeals
 
-An appeal can be filed in 14 days through the website at goingdark.social. Responses arrive in 14 days. Decisions after the appeal are final.
+Use the in-app Appeal button on the warning page. If the site is unavailable, send a DM to `@fanfare@goingdark.social`.
+File appeals within 14 days.
+Responses arrive in 14 days.
+Decisions after the appeal are final.
 


### PR DESCRIPTION
## Summary
- replace DM directions with a standard appeal message across docs
- clarify moderation guideline appeal timelines

## Testing
- `pre-commit run --files content/docs/legal/appeals.md`
- `pre-commit run --files content/docs/mods/appeals.md`
- `pre-commit run --files content/docs/community/community-guidelines.md` *(fails: numerous style issues)*
- `pre-commit run --files content/docs/policies/moderation-guidelines.md`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68aaf5e920948322a5b15a7ad3ebaf7e