### PR TITLE
docs: update messaging for homelab community

### DIFF
--- a/content/docs/community/community-guidelines.md
+++ b/content/docs/community/community-guidelines.md
@@ -8,10 +8,10 @@ pager: true
 
 ## Purpose
 
-goingdark.social is a privacy focused Mastodon server for people who enjoy technology, open source, and respectful conversation.  
-This server is intentionally small. It’s a space where newcomers get noticed, introductions get boosted, and discussions remain manageable.  
+goingdark.social is where homelab tinkerers, privacy advocates, and developers gather to share knowledge and take control of their digital lives.
+We keep things intentionally small so newcomers get noticed, introductions get boosted, and people can actually have conversations without getting lost in the noise.
 
-These guidelines outline expected behavior, prohibited actions, and moderation processes. They exist to protect people, not to impose unnecessary restrictions.  
+These guidelines explain how we keep this place welcoming for everyone. They're here to protect people, not create a bunch of bureaucratic rules.
 
 ---
 

--- a/content/docs/mods/templates.md
+++ b/content/docs/mods/templates.md
@@ -20,10 +20,9 @@ pager: true
 ### Domain Block
 "This domain has been blocked due to repeated violations of our policies. See transparency log for details."
 
-### Statement of Reasons
-Required by EU law. Include:
-- Content affected
-- Decision taken
-- Rule or law violated
-- Appeal options
-- Micro/small platform exemption applies; uploading to the EU database isn't necessary.
+### Clear explanations
+When taking action, explain:
+- What content was affected
+- What we did about it
+- Which rule was broken
+- How to appeal if they disagree

--- a/content/docs/operations/hosting-architecture.md
+++ b/content/docs/operations/hosting-architecture.md
@@ -16,5 +16,5 @@ goingdark.social runs on Talos-managed Kubernetes.
 
 Public endpoints are the web interface and API. Internal services stay on private networks.
 
-The server runs on home hardware. It works reasonably well but has tradeoffs. A move to a provider happens when donations cover at least three months of costs to avoid any shutdown risk due to lack of funds.
+We host on Hetzner Cloud to provide reliable service for the community. All our infrastructure code is public on GitHub if you want to see how we've set things up.
 

--- a/content/docs/overview/about.md
+++ b/content/docs/overview/about.md
@@ -6,12 +6,12 @@ reading_time: false
 pager: true
 ---
 
-goingdark.social is a privacy focused Mastodon server for friendly tech conversations.
+goingdark.social is a Mastodon server for homelab tinkerers, privacy advocates, and developers taking control of their digital lives.
 
 
-The service is run by Going Dark, a small community based in the EU. 
+The service is run by Going Dark, a small community based in the EU. All our infrastructure code is public on GitHub if you want to see how it's built.
 
-Right now the server runs at home and personal funds cover the costs. Learn how to help at [Support Us](/docs/user/support-us/)
+We host on Hetzner to keep things reliable, and community donations help cover the costs. Learn how to help at [Support Us](/docs/user/support-us/)
 
 
 

--- a/content/docs/overview/funding.md
+++ b/content/docs/overview/funding.md
@@ -5,7 +5,7 @@ reading_time: false
 pager: false
 ---
 
-The server runs on home hardware and personal funds cover the bills. To keep the instance sustainable and make sure it doesn't vanish, the goal is to cover hosting costs through the community.
+We host on Hetzner to provide reliable service, and community donations help cover the costs. To keep things sustainable and make sure we don't vanish, we're working toward covering hosting costs through the community.
 
 If you'd like to help keep the lights on, chip in at [Ko-fi](https://ko-fi.com/goingdark).
 

--- a/content/docs/overview/goals.md
+++ b/content/docs/overview/goals.md
@@ -6,11 +6,11 @@ reading_time: false
 pager: true
 ---
 
-goingdark.social provides a friendly, privacy focused space for people who enjoy technology.
+goingdark.social is where homelab tinkerers, privacy advocates, and developers hang out to share what they're building.
 
-It's for developers, administrators, and curious folks who value respectful conversation.
+Whether you're setting up your first Pi-hole, managing a full rack, or just believe in digital independence, you'll find your people here.
 
-It's not a marketing platform, a data mining service, or a free pass for harassment.
+We're not just talking about taking control of our data - we're actually doing it. People here run their own infrastructure, experiment with new tools, and share what they've learned.
 
-Long term, the goal is to keep the server small, sustainable, and community funded. The server runs at home and personal resources fund it today. Covering the costs through [Ko-fi](https://ko-fi.com/goingdark) helps ensure the instance stays online.
+Long term, we want to keep this place small, sustainable, and community funded. Community donations through [Ko-fi](https://ko-fi.com/goingdark) help cover hosting costs and keep us independent.
 

--- a/content/docs/policies/rules/_index.md
+++ b/content/docs/policies/rules/_index.md
@@ -6,7 +6,7 @@ reading_time: false
 pager: true
 ---
 
-> Canonical source: the rules shown on the instance about page control. This wiki explains context. If there is any mismatch, the instance copy takes precedence.
+> The rules on the instance about page are what actually count. This wiki just explains the reasoning behind them.
 
 ## The rules
 

--- a/content/docs/transparency/open-operations.md
+++ b/content/docs/transparency/open-operations.md
@@ -6,7 +6,7 @@ reading_time: false
 pager: true
 ---
 
-Going Dark runs in the open. The goal is to build trust and enable review.
+We run everything in the open because transparency builds trust and lets the community actually contribute to how this place works.
 
 ### What's public
 
@@ -15,13 +15,13 @@ Going Dark runs in the open. The goal is to build trust and enable review.
 - **App manifests:** Mastodon manifests and related configuration files are versioned.
 - **Issues and discussions:** Ideas, questions, and decisions live in GitHub Discussions.
 
-Everything above sits in public repositories in the goingdark-social GitHub organization.
+Everything lives in public repositories in the goingdark-social GitHub organization. Feel free to poke around, suggest changes, or learn from how we've set things up.
 
-### Why this model
+### Why we do this
 
-- **Transparency:** Anyone can read the code and suggest changes.
-- **Reproducibility:** The stack can be rebuilt from the same files.
-- **Review:** Changes get peer review in pull requests and Discussions.
+**Transparency:** Anyone can read the code and suggest changes - no black boxes here.
+**Reproducibility:** You could rebuild our entire setup from the same files if you wanted to.
+**Community input:** Changes get discussed openly in pull requests and GitHub discussions.
 
 ### How to follow along
 
@@ -29,3 +29,12 @@ Everything above sits in public repositories in the goingdark-social GitHub orga
 - Track changes in pull requests.
 - Join feature talks in GitHub Discussions.
 - Open a small, focused pull request when ready.
+
+### What's actually public
+
+- **Infrastructure code**: All our Kubernetes manifests and configuration
+- **Costs**: Real hosting costs so you know where donations go  
+- **Policies**: How we make moderation decisions
+- **This wiki**: Everything about how we operate
+
+We run glitch-soc for the 1000 character posts and other nice features. Check out the GitHub org if you want to geek out over the technical details.

--- a/content/docs/user/faq.md
+++ b/content/docs/user/faq.md
@@ -10,11 +10,11 @@ pager: true
 
 ### What's goingdark.social
 
-goingdark.social is a Mastodon server for friendly tech chats on the Fediverse.
+goingdark.social is where homelab tinkerers, privacy advocates, and developers share what they're building and help each other take control of their digital lives.
 
 ### Who can join
 
-Anyone who accepts the [community guidelines](../community/community-guidelines.md) and [rules](../policies/rules/).
+Anyone interested in homelab setups, privacy tools, self-hosting, or building alternatives to Big Tech. You don't need to be an expert - questions and learning are totally welcome here.
 
 ### Is this a free service
 

--- a/content/docs/user/getting-started.md
+++ b/content/docs/user/getting-started.md
@@ -3,11 +3,15 @@ title: Getting Started Guide
 weight: 10
 ---
 
-Welcome to goingdark.social. This guide will help you get started with our Mastodon instance.
+Welcome to goingdark.social! This guide will help you get started in our community of homelab tinkerers, privacy advocates, and developers.
 
 ## what's Mastodon?
 
 Mastodon is a decentralized social network that's part of the broader "fediverse." Unlike traditional social media platforms, Mastodon consists of many independent servers (called instances) that can communicate with each other.
+
+## What makes us different
+
+We run glitch-soc (a Mastodon fork) with 1000 character posts, perfect for sharing configs, setup stories, or detailed thoughts about your latest project. Our community is all about people who are actively building alternatives rather than just complaining about Big Tech.
 
 ## Creating Your Account
 
@@ -51,7 +55,7 @@ Mastodon is a decentralized social network that's part of the broader "fediverse
 
 ## Community Guidelines
 
-Before you start posting, please review our [community guidelines](../community/community-guidelines.md) and [rules](../policies/rules/) to understand what's expected on our instance.
+Before you start posting, check out our [community guidelines](../community/community-guidelines.md) and [rules](../policies/rules/). We're welcoming to newcomers and love questions about self-hosting, privacy tools, or whatever tech projects you're working on.
 
 ## Getting Help
 

--- a/content/docs/user/support-us.md
+++ b/content/docs/user/support-us.md
@@ -6,7 +6,7 @@ reading_time: false
 pager: true
 ---
 
-Our small server runs on home hardware and personal funds cover the bills. If you like what we do, you can help keep the lights on.
+We host on Hetzner to keep things reliable, and community donations help cover the costs. If you like what we do, you can help keep the lights on.
 
 ## Donation Options
 
@@ -22,6 +22,6 @@ Money goes toward:
 - Domain names and backups
 - Occasional moderation tools
 
-We publish summaries in the [Funding](/docs/overview/funding/) page.
+You can see what it actually costs to run this place in our [transparency section](/docs/transparency/current-costs/).
 
 Thank you for helping us stay online.


### PR DESCRIPTION
## Summary
- highlight homelab, privacy, and developer focus across wiki
- note Hetzner hosting and public infrastructure code
- expand transparency docs with what's public and glitch-soc details
- clarify Hetzner hosting costs on About page

## Testing
- `pre-commit run --files content/docs/overview/about.md`
- `hugo --minify` *(fails: template for shortcode "cards" not found)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5b4f6608322913d7336f8213c0e