### PR TITLE
fix: install tailwind dependencies for site build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,15 +44,16 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-    - name: Install Tailwind CSS
-      run: npm install -g tailwindcss
+    - name: Install Tailwind
+      run: npm install @tailwindcss/cli tailwindcss @tailwindcss/typography
     - name: Setup Pages
       id: pages
       uses: actions/configure-pages@v5
     - name: Build with Hugo
       env:
         HUGO_ENVIRONMENT: production
-        TAILWINDCSS_BINARY: tailwindcss
+        TAILWINDCSS_BINARY: npx tailwindcss
+        NODE_PATH: ${{ github.workspace }}/node_modules
       run: |
         echo "Hugo Cache Dir: $(hugo config | grep cachedir)"
         hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # IDEs
 .idea/
 
+# Node
+node_modules/
+package-lock.json
+package.json
+
 # Hugo
 resources/
 public/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The site loads in dark mode by default, and you can switch themes from the heade
 
 ## Local development
 
-Install the extended version of Hugo, Node, and the Tailwind command line tool. The theme builds its styles with Tailwind, so the tool has to be on your path.
+Install the extended version of Hugo and Node. Install the Tailwind command line tool and typography plugin, then start the server.
 
 ```shell
-npm install -g tailwindcss
-hugo server
+npm install @tailwindcss/cli tailwindcss @tailwindcss/typography
+NODE_PATH=node_modules TAILWINDCSS_BINARY="npx tailwindcss" hugo server
 ```
 
 The site runs at `http://localhost:1313`.


### PR DESCRIPTION
## Summary
- remove Node package files and ignore local installs
- install Tailwind CLI and typography plugin during publish workflow
- document local setup using npx

## Testing
- `python -m pre_commit run --files README.md .github/workflows/publish.yaml .gitignore`
- `NODE_PATH=$PWD/node_modules TAILWINDCSS_BINARY="npx tailwindcss" hugo --minify --baseURL "http://example.com/"`


------
https://chatgpt.com/codex/tasks/task_e_68c459baa68c8322952fe156f7f721fc