### PR TITLE
fix(ci): install Tailwind CLI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,8 +44,8 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: 20
-    - name: Install Tailwind CSS
-      run: npm install -g tailwindcss
+    - name: Install Tailwind CSS CLI
+      run: npm install -g tailwindcss @tailwindcss/cli
     - name: Setup Pages
       id: pages
       uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ The site loads in dark mode by default, and you can switch themes from the heade
 
 ## Local development
 
-Install the extended version of Hugo, Node, and the Tailwind command line tool. The theme builds its styles with Tailwind, so the tool has to be on your path.
+Install the extended version of Hugo, Node, and the Tailwind command line interface package. The theme builds its styles with Tailwind, so the interface has to be on your path.
 
 ```shell
-npm install -g tailwindcss
+npm install -g tailwindcss @tailwindcss/cli
 hugo server
 ```
 


### PR DESCRIPTION
## Summary
- install Tailwind CLI alongside Tailwind CSS in publish workflow
- mention Tailwind CLI in local development instructions

## Testing
- `pre-commit run --files README.md`
- `TAILWINDCSS_BINARY=tailwindcss hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68c5351962248322b69d2a418a7227d6