### PR TITLE
chore(vale): adopt community-friendly style

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,60 +1,33 @@
-MinAlertLevel = error
+MinAlertLevel = warning
 StylesPath = .vale
+Vocab = friendly
+Packages = alex, write-good
 Ignored = LICENSE.md, hugo-blox/**
 
 [*.md]
-BasedOnStyles = alex, Google, Microsoft, proselint, write-good, Project, Vale, gitlab
+BasedOnStyles = alex, write-good, Project, Vale, friendly
 
-# Disable Vale's spelling to allow for the use of our custom dictionary in styles/Project/Spelling.yml
-Vale.Spelling = NO
-
-# Disable Gitlab checks that don't apply to Project
-gitlab.RelativeLinks = NO
-gitlab.ReferenceLinks = NO
-gitlab.AlertBoxStyle = NO
-gitlab.BadgeCapitalization = NO
-gitlab.CIConfigFile = NO
-gitlab.DefaultBranch = NO
-gitlab.GitLabFlavoredMarkdown = NO
-gitlab.OutdatedVersions = NO
-gitlab.OxfordComma = NO
-gitlab.Possessive = NO
-gitlab.Spelling = NO
-gitlab.TabsLinks = NO
-gitlab.VersionText = NO
-gitlab.VersionTextSingleLine = NO
-gitlab.EOLWhitespace = NO
-gitlab.Normal = NO
-gitlab.InternalLinkExtension = NO
-gitlab.NonStandardQuotes = NO
-
-# Covered by Alex
-gitlab.InclusionCultural = NO
-gitlab.InclusionGender = NO
-gitlab.Simplicity = NO
-
-# Don't enforce oxford comma
-Google.OxfordComma = NO
-
-
-# Ignore Google duplicates
+Google.Contractions = NO
+Google.FirstPerson = NO
+Google.We = NO
 Google.Will = NO
-Google.Latin = NO
+Google.Passive = NO
+Google.Semicolons = NO
 
-# Ignore Microsoft duplicates
-Microsoft.We = NO
+Microsoft.Contractions = NO
 Microsoft.FirstPerson = NO
+Microsoft.We = NO
+Microsoft.Passive = NO
 Microsoft.Foreign = NO
-Microsoft.Quotes = NO
-Microsoft.GeneralURL = NO
 
-# ignore individual tokens
-# Ignore the markdown link to check the last word of the link: ](.
-# Ignore markdown image with alt: ![
-# ignore v#.##
-# ignore ##px
-TokenIgnores = (\(#.*\)),(\]\(),(http.*),({{<\s*\/?expand),(\!\[),(\d.*px),(\d\.\d\.\d)
+write-good.TooWordy = NO
+write-good.Weasel = NO
+write-good.ThereIs = NO
+write-good.So = NO
+write-good.Passive = NO
 
-# ignore whole tags:
-# Ignore hugo tags
-BlockIgnores = (\{\{<\s*\/?.*>\}\}),(\{\{\<\/\*.*\*\/\>\}\})
+proselint.Very = NO
+proselint.Hedging = NO
+
+TokenIgnores = (\(#.*\)),(\]\(),(http.*),(\{\{<\s*\/?.*>\}\}),(\!\[),(\d.*px),(\d\.\d\.\d)
+BlockIgnores = (\{\{<\s*\/?.*>\}\}),(\{\{<\/\*.*\*\/\>}\})

--- a/.vale/config/vocabularies/friendly/accept.txt
+++ b/.vale/config/vocabularies/friendly/accept.txt
@@ -1,0 +1,85 @@
+yeah
+yep
+nope
+ok
+okay
+cool
+awesome
+sweet
+nice
+neat
+wow
+whoa
+hey
+hi
+hello
+sup
+thanks
+thx
+btw
+fyi
+tbh
+honestly
+seriously
+totally
+super
+really
+pretty
+quite
+definitely
+absolutely
+kinda
+sorta
+gonna
+wanna
+gotta
+lemme
+dunno
+emoji
+emojis
+DM
+DMs
+PM
+PMs
+lol
+omg
+wtf
+tbh
+imo
+imho
+afaik
+iirc
+fwiw
+folks
+peeps
+gang
+crew
+team
+buddies
+friends
+community
+squad
+no worries
+no problem
+sounds good
+looks good
+gotcha
+got it
+makes sense
+fair enough
+true that
+for sure
+right on
+word
+app
+apps
+pic
+pics
+vid
+vids
+doc
+docs
+config
+configs
+repo
+repos

--- a/.vale/friendly/AllowEmphasis.yml
+++ b/.vale/friendly/AllowEmphasis.yml
@@ -1,0 +1,14 @@
+extends: existence
+message: "Emphasis words like '%s' add personality to your writing."
+level: suggestion
+ignorecase: true
+tokens:
+  - really
+  - pretty
+  - quite
+  - super
+  - totally
+  - definitely
+  - absolutely
+  - honestly
+  - seriously

--- a/.vale/friendly/AllowFragments.yml
+++ b/.vale/friendly/AllowFragments.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Sentence fragments are totally fine in casual writing!"
+level: suggestion
+tokens:
+  - "^And "
+  - "^But "
+  - "^So "
+  - "^Because "
+  - "^Though "
+  - "^Although "

--- a/.vale/friendly/AvoidCorporateSpeak.yml
+++ b/.vale/friendly/AvoidCorporateSpeak.yml
@@ -1,0 +1,25 @@
+extends: existence
+message: "Replace '%s' with simpler, friendlier language."
+level: error
+ignorecase: true
+tokens:
+  - leverage
+  - utilize
+  - facilitate
+  - optimize
+  - strategize
+  - ideate
+  - operationalize
+  - actualize
+  - incentivize
+  - monetize
+  - prioritize
+  - maximize
+  - streamline
+  - spearhead
+  - champion
+  - drive
+  - execute
+  - deliver
+  - implement
+  - deploy

--- a/.vale/friendly/EncourageCasualLanguage.yml
+++ b/.vale/friendly/EncourageCasualLanguage.yml
@@ -1,0 +1,18 @@
+extends: substitution
+message: "Try '%s' for a more relaxed tone."
+level: suggestion
+ignorecase: true
+swap:
+  regarding: about
+  concerning: about
+  in order to: to
+  with respect to: about
+  in terms of: about
+  due to the fact that: because
+  for the reason that: because
+  it is important to note: note that
+  please be advised: heads up
+  we would like to inform you: just so you know
+  at this point in time: now
+  in the near future: soon
+  at the present time: now

--- a/.vale/friendly/EncourageContractions.yml
+++ b/.vale/friendly/EncourageContractions.yml
@@ -1,0 +1,17 @@
+extends: substitution
+message: "Consider using '%s' for a more conversational tone."
+level: suggestion
+ignorecase: true
+swap:
+  you are: you're
+  we are: we're
+  it is: it's
+  that is: that's
+  do not: don't
+  cannot: can't
+  will not: won't
+  would not: wouldn't
+  should not: shouldn't
+  they are: they're
+  we have: we've
+  I have: I've

--- a/.vale/friendly/EncouragePersonalPronouns.yml
+++ b/.vale/friendly/EncouragePersonalPronouns.yml
@@ -1,0 +1,11 @@
+extends: substitution
+message: "Consider using '%s' to sound more personal and friendly."
+level: suggestion
+ignorecase: true
+swap:
+  one should: you should
+  one can: you can
+  one might: you might
+  users can: you can
+  individuals may: you might
+  people should: you should

--- a/.vale/friendly/EncourageQuestions.yml
+++ b/.vale/friendly/EncourageQuestions.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Great! Questions make writing more engaging and conversational."
+level: suggestion
+scope: sentence
+tokens:
+  - "\\?"

--- a/.vale/friendly/WarnAboutOverlyFormal.yml
+++ b/.vale/friendly/WarnAboutOverlyFormal.yml
@@ -1,0 +1,16 @@
+extends: existence
+message: "Consider using friendlier language instead of '%s'."
+level: warning
+ignorecase: true
+tokens:
+  - furthermore
+  - moreover
+  - nevertheless
+  - notwithstanding
+  - consequently
+  - accordingly
+  - therefore
+  - hence
+  - thus
+  - henceforth
+  - heretofore

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Going Dark Wiki
 
-Community wiki for [goingdark.social](https://goingdark.social).
+community wiki for [goingdark.social](https://goingdark.social).
 Built with [Hugo](https://gohugo.io) and the Hugo Blox documentation theme.
 The site loads in dark mode by default, and you can switch themes from the header.
 
@@ -17,7 +17,7 @@ The site runs at `http://localhost:1313`.
 
 ## Linting
 
-[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project` along with the Write Good, Microsoft, and Google packages. These rules cover Fediverse terms, require alt text, and prefer code formatting for handles. Docs in `content/docs/legal/` are excluded.
+[Vale](https://vale.sh) checks the docs with project-specific rules in `.vale/Project`, community-friendly rules in `.vale/friendly`, and the Alex and Write Good packages. These rules cover Fediverse terms, encourage casual language, require alt text, and prefer code formatting for handles. Docs in `content/docs/legal/` are excluded.
 
 1. Run `vale sync` once to download the external packages.
 2. Install the `pre-commit` tool with `pre-commit install`.
@@ -27,7 +27,7 @@ Use `pre-commit run --files path/to/file.md` to lint a file manually. The workfl
 
 ## Deployment
 
-Commits to `main` deploy to GitHub Pages via the included workflow.
+Commits to `main` publish to GitHub Pages through the included workflow.
 
 ## Funding
 


### PR DESCRIPTION
## Summary
- replace Vale config with community-friendly defaults
- add friendly style rules and vocabulary
- document updated Vale setup

## Testing
- `vale README.md`
- `pre-commit run --files README.md .vale.ini`
- `PATH="$PWD:$PATH" hugo`
- `PATH="$PWD:$PATH" HUGO_ENVIRONMENT=production hugo --minify`
- `npx pagefind --source "public"`


------
https://chatgpt.com/codex/tasks/task_e_68c8256a29108322991cac2210ec6ec4