### PR TITLE
docs: clarify mastodon hashtag guidance

### DIFF
--- a/.vale/Project/AvoidPlatformOwnership.yml
+++ b/.vale/Project/AvoidPlatformOwnership.yml
@@ -1,0 +1,16 @@
+extends: existence
+message: "Avoid '%s' - it sounds like we built our own platform. Mention this is Mastodon."
+level: warning
+ignorecase: true
+tokens:
+  - our federated network
+  - our platform
+  - our social network
+  - we do not have
+  - we don't have
+  - our network
+  - our federation
+  - our instance works
+  - we built
+  - we designed
+  - our system

--- a/.vale/Project/InstancePossessive.yml
+++ b/.vale/Project/InstancePossessive.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Consider rephrasing '%s' to clarify we run a Mastodon instance, not our own platform."
+level: warning
+ignorecase: true
+tokens:
+  - goingdark.social works
+  - goingdark.social uses
+  - goingdark.social has
+  - goingdark.social does not
+  - goingdark.social doesn't

--- a/.vale/Project/MastodonAttribution.yml
+++ b/.vale/Project/MastodonAttribution.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Good! Mentioning Mastodon helps users understand the platform."
+level: suggestion
+ignorecase: true
+tokens:
+  - Mastodon
+  - Fediverse
+  - federated social media
+  - ActivityPub

--- a/.vale/Project/RequireMastodonContext.yml
+++ b/.vale/Project/RequireMastodonContext.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "When explaining platform features, mention this is how Mastodon works."
+level: suggestion
+scope: paragraph
+tokens:
+  - algorithm
+  - recommendation
+  - federated
+  - discovery
+  - hashtag

--- a/.vale/Project/VaguePlatformReferences.yml
+++ b/.vale/Project/VaguePlatformReferences.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: "Use '%s' to be clearer about the platform."
+level: warning
+ignorecase: true
+swap:
+  "this platform": "Mastodon"
+  "this site": "goingdark.social (our Mastodon instance)"
+  "this network": "Mastodon and the Fediverse"
+  "here": "on Mastodon"
+  "traditional social sites": "algorithmic platforms like Twitter"

--- a/content/docs/user/hashtags.md
+++ b/content/docs/user/hashtags.md
@@ -1,0 +1,55 @@
+---
+title: "Using hashtags on Mastodon"
+weight: 25
+toc: true
+reading_time: false
+pager: true
+---
+
+Hashtags help people discover your posts on Mastodon. Unlike Twitter or Instagram, Mastodon doesn't use algorithms to show you content. Instead, hashtags connect your posts with people interested in those topics. goingdark.social runs on Mastodon, so these tips match how our instance behaves.
+
+## Why posts don't get seen
+
+Mastodon works differently than algorithm driven social media. There's no recommendation engine pushing content to people. If you skip hashtags, only your followers will see your posts.
+
+## How people find posts on Mastodon
+
+When someone searches for a hashtag or follows one, your posts with that tag appear in their results. That's usually how people outside your follower network discover what you share.
+
+## Creating good hashtags
+
+Add the `#` symbol before relevant words. Sharing cat photos? Use `#Cats` or `#CatsOfMastodon`.
+
+For multiple words, combine them and capitalize each word: `#CatsOfMastodon`. That format helps screen readers pronounce hashtags well for people who rely on them.
+
+## Choosing the right tags
+
+Search for your topic to see which hashtags people actually use. Mix popular tags like `#Photography` with specific ones like `#FilmPhotography`. Popular tags reach more people but move quickly. Specific tags reach engaged communities.
+
+## Hashtag placement
+
+Put hashtags anywhere in your post. For a cleaner appearance, add them below a blank line at the end. They'll display in smaller text but work the same way.
+
+## Finding content
+
+Search hashtags to find posts and communities. Follow hashtags to see related posts in your home timeline, even from people you don't follow yet.
+
+## Common mistakes
+
+- Posting without hashtags
+- Using tags nobody else uses
+- Relying only on extremely popular tags where posts get buried
+- Adding irrelevant hashtags
+
+## Numbers and dates
+
+Use `#year2024` for years because numeric only hashtags like `#2024` don't work on Mastodon.
+
+## Beyond hashtags
+
+- Engage with hashtag communities
+- Join Mastodon groups for wider reach
+- Post when your audience is active
+- Participate in conversations instead of only broadcasting
+
+Hashtags are essential for discovery on Mastodon. Use them consistently to help people find your content and connect with communities that share your interests.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "production": "HUGO_ENVIRONMENT=production hugo --minify"
   },
   "dependencies": {
-    "tailwindcss": "^4.1.0",
-    "@tailwindcss/typography": "^0.5.0"
+    "@tailwindcss/cli": "^4.1.13",
+    "@tailwindcss/typography": "^0.5.16",
+    "tailwindcss": "^4.1.13"
   },
   "devDependencies": {
     "pagefind": "^1.0.0"


### PR DESCRIPTION
## Summary
- rewrite the hashtag guide to describe Mastodon’s discovery model without implying platform ownership
- add Vale rules that flag platform-ownership language and vague references to the instance
- add the Tailwind CLI package so local builds provide the required binary

## Testing
- `vale content/docs/user/hashtags.md`
- `PATH="$PWD:$PATH" HUGO_ENVIRONMENT=production hugo --minify`
- `npx pagefind --source "public"`


------
https://chatgpt.com/codex/tasks/task_e_68c84e8d1f348322b8dab96928d1e841